### PR TITLE
Story/vethub 24

### DIFF
--- a/src/components/MCQ/MCQQuestion.vue
+++ b/src/components/MCQ/MCQQuestion.vue
@@ -7,7 +7,7 @@
       :key="key"
       class="mcq-option"
       :class="optionClass(key)"
-      @click="selectCurrentOption(key)"
+      @click="selectedOption = key"
     >
       <MCQOption
         :option-key="key"
@@ -18,13 +18,7 @@
     </li>
   </ul>
 
-  <button
-    class="mcq-submit"
-    :disabled="!selectedOption || submitted"
-    @click="submit"
-  >
-    Submit
-  </button>
+  <button class="mcq-submit" @click="submit">Submit</button>
 </template>
 
 <script setup lang="ts">
@@ -36,12 +30,8 @@ const selectedOption = ref<string | null>(null);
 const submitted = ref<boolean>(false);
 
 const submit = () => {
+  if (!selectedOption.value) return;
   submitted.value = true;
-};
-
-// Only allow selection if the quiz is not submitted
-const selectCurrentOption = (key: string) => {
-  if (!submitted.value) selectedOption.value = key;
 };
 
 const optionClass = (key: string) => {

--- a/tests/components/MCQ.test.ts
+++ b/tests/components/MCQ.test.ts
@@ -96,4 +96,9 @@ describe("MCQ.vue", () => {
     expect(correctOption.classes()).toContain("correct");
     expect(correctOption.find("input").classes()).toContain("correct");
   });
+
+  test("Able to submit without selecting an option", async () => {
+    await wrapper.find(".mcq-submit").trigger("click");
+    expect(wrapper.vm.submitted).toBe(false);
+  });
 });


### PR DESCRIPTION
Ability to skip a question.

Removed the disable which allows the submit button to be pressed but at the moment no action occurs. This is to be expanded in the quiz level where there will be stack sorting for the questions that will be skipped but since this is just 1 question, the change is minimal.

To test:

- Run `yarn dev` and then navigate to https://localhost:5173
- Click submit
- Click an option and then resubmit
- Run `yarn test` to run the updated tests.