### PR TITLE
Added the filtering functionality for filtering Questions based on tags

### DIFF
--- a/src/components/QuestionStore.ts
+++ b/src/components/QuestionStore.ts
@@ -39,3 +39,14 @@ export function getUniquePropertyValues(tagProps: tags[]) {
     system: [...uniqueValues.system],
   };
 }
+
+export function filterQuestionsByTags(
+  questions: MCQuestion[],
+  filterTags: tags,
+): MCQuestion[] {
+  return questions.filter((question) => {
+    return Object.entries(filterTags).every(([key, value]) => {
+      return question.tags[key as keyof tags] === value;
+    });
+  });
+}

--- a/tests/components/QuestionStore.test.ts
+++ b/tests/components/QuestionStore.test.ts
@@ -1,28 +1,44 @@
 import { test, expect, vi } from "vitest";
-import { getQuestionsRandomly, shuffleArray } from "@components/QuestionStore";
+import {
+  filterQuestionsByTags,
+  getQuestionsRandomly,
+  shuffleArray,
+} from "@components/QuestionStore";
 
 const questions = [
   {
     statement: "The question 1",
-    tags: ["tag1"],
+    tags: {
+      course: "VETS2011",
+      subject: "Physiology",
+      system: "Neurophysiology",
+    },
     optionsList: [
-      { optionValue: "Answer A Q0", optionCorrect: false },
-      { optionValue: "Answer B Q0", optionCorrect: true },
-      { optionValue: "Answer C Q0", optionCorrect: false },
+      { optionValue: "Answer A Q1", optionCorrect: false },
+      { optionValue: "Answer B Q1", optionCorrect: true },
+      { optionValue: "Answer C Q1", optionCorrect: false },
     ],
   },
   {
     statement: "The question 2",
-    tags: ["tag2", "tag1"],
+    tags: {
+      course: "VETS2022",
+      subject: "Anatomy",
+      system: "Musculoskeletal",
+    },
     optionsList: [
       { optionValue: "Answer A Q2", optionCorrect: false },
-      { optionValue: "Answer B Q2", optionCorrect: false },
-      { optionValue: "Answer C Q2", optionCorrect: true },
+      { optionValue: "Answer B Q2", optionCorrect: true },
+      { optionValue: "Answer C Q2", optionCorrect: false },
     ],
   },
   {
     statement: "The question 3",
-    tags: [],
+    tags: {
+      course: "VETS2011",
+      subject: "Physiology",
+      system: "Cardiovascular",
+    },
     optionsList: [
       { optionValue: "Answer A Q3", optionCorrect: true },
       { optionValue: "Answer B Q3", optionCorrect: false },
@@ -31,10 +47,15 @@ const questions = [
   },
   {
     statement: "The question 4",
+    tags: {
+      course: "VETS2011",
+      subject: "Physiology",
+      system: "Neurophysiology",
+    },
     optionsList: [
-      { optionValue: "Answer A Q3", optionCorrect: true },
-      { optionValue: "Answer B Q3", optionCorrect: false },
-      { optionValue: "Answer C Q3", optionCorrect: false },
+      { optionValue: "Answer A Q4", optionCorrect: true },
+      { optionValue: "Answer B Q4", optionCorrect: false },
+      { optionValue: "Answer C Q4", optionCorrect: false },
     ],
   },
 ];
@@ -75,4 +96,46 @@ test("should contain all the same elements", () => {
 test("should not return the same array", () => {
   const shuffled = shuffleArray([...questions]);
   expect(shuffled).to.not.deep.equal(questions);
+});
+
+test("Filter questions by a specific course, subject, and system", () => {
+  const filterTags = {
+    course: "VETS2011",
+    subject: "Physiology",
+    system: "Neurophysiology",
+  };
+  const filteredQuestions = filterQuestionsByTags(questions, filterTags);
+  expect(filteredQuestions.length).equal(2);
+  expect(
+    filteredQuestions.every(
+      (q) =>
+        q.tags.course === "VETS2011" &&
+        q.tags.subject === "Physiology" &&
+        q.tags.system === "Neurophysiology",
+    ),
+  ).toBe(true);
+});
+
+test("Filter questions by course and subject, expecting multiple results", () => {
+  const filterTags = {
+    course: "VETS2011",
+    subject: "Physiology",
+  };
+  const filteredQuestions = filterQuestionsByTags(questions, filterTags);
+  expect(filteredQuestions.length).equal(3);
+  expect(
+    filteredQuestions.every(
+      (q) => q.tags.course === "VETS2011" && q.tags.subject === "Physiology",
+    ),
+  ).toBe(true);
+});
+
+test("Filter questions with no matching tags, expecting empty array", () => {
+  const filterTags = {
+    course: "VETS4044",
+    subject: "Unknown",
+  };
+  const filteredQuestions = filterQuestionsByTags(questions, filterTags);
+  expect(filteredQuestions.length).equal(0);
+  expect(filteredQuestions).toEqual([]);
 });

--- a/tests/components/QuestionStore.test.ts
+++ b/tests/components/QuestionStore.test.ts
@@ -108,10 +108,10 @@ test("Filter questions by a specific course, subject, and system", () => {
   expect(filteredQuestions.length).equal(2);
   expect(
     filteredQuestions.every(
-      (q) =>
-        q.tags.course === "VETS2011" &&
-        q.tags.subject === "Physiology" &&
-        q.tags.system === "Neurophysiology",
+      (question) =>
+        question.tags.course === "VETS2011" &&
+        question.tags.subject === "Physiology" &&
+        question.tags.system === "Neurophysiology",
     ),
   ).toBe(true);
 });
@@ -125,7 +125,9 @@ test("Filter questions by course and subject, expecting multiple results", () =>
   expect(filteredQuestions.length).equal(3);
   expect(
     filteredQuestions.every(
-      (q) => q.tags.course === "VETS2011" && q.tags.subject === "Physiology",
+      (question) =>
+        question.tags.course === "VETS2011" &&
+        question.tags.subject === "Physiology",
     ),
   ).toBe(true);
 });


### PR DESCRIPTION
The quiz filtering functionality allows users to refine their quiz selection based on specific criteria such as course, subject, and system. 
I have a question @anzahkhan: Should the filtering functionality permit users to select multiple subjects simultaneously, such as both Anatomy and Physiology, or should it restrict selection to just one subject per category?
for testing this functionality :
run the command:
`yarn vitest tests/components/QuestionStore.test.ts`