### PR TITLE
Feature/vethub 72

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,15 +2,31 @@
 import { ref } from "vue";
 import MCQQuiz from "@components/MCQ/MCQQuiz.vue";
 import StartPage from "@components/StartPage.vue";
-import { getQuestionsRandomly } from "./components/QuestionStore";
+import {
+  filterQuestionsByTags,
+  getQuestionsRandomly,
+} from "./components/QuestionStore";
 import { useQuizStore } from "./store/QuizStore";
+import { MCQuestion, SelectedTags } from "./types/MCQ";
+import { getAllQuestions } from "./components/DataAccessLayer";
 
 const quizQuestions = ref(0);
 const questionsQueue = useQuizStore();
 const quizStarted = ref<boolean>(false);
 
-const handleStartQuiz = (questionAmount: number) => {
-  const quizAmount = getQuestionsRandomly(questionAmount);
+const handleStartQuiz = ({
+  questionAmount,
+  selectedTags,
+}: {
+  questionAmount: number;
+  selectedTags: SelectedTags;
+}) => {
+  const questions: MCQuestion[] = getAllQuestions();
+  const filteredquestions: MCQuestion[] = filterQuestionsByTags(
+    questions,
+    selectedTags,
+  );
+  const quizAmount = getQuestionsRandomly(questionAmount, filteredquestions);
   quizQuestions.value = quizAmount.length;
   questionsQueue.initialiseQuiz(quizAmount);
   quizStarted.value = true;

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,10 @@ import {
 } from "./components/QuestionStore";
 import { useQuizStore } from "./store/QuizStore";
 import { MCQuestion, SelectedTags } from "./types/MCQ";
-import { getAllQuestions } from "./components/DataAccessLayer";
+import {
+  getAllQuestions,
+  getDummyQuestions,
+} from "./components/DataAccessLayer";
 
 const quizQuestions = ref(0);
 const questionsQueue = useQuizStore();
@@ -17,11 +20,16 @@ const quizStarted = ref<boolean>(false);
 const handleStartQuiz = ({
   questionAmount,
   selectedTags,
+  dummyBoolean,
 }: {
   questionAmount: number;
   selectedTags: SelectedTags;
+  dummyBoolean: boolean;
 }) => {
-  const questions: MCQuestion[] = getAllQuestions();
+  const questions: MCQuestion[] = dummyBoolean
+    ? getAllQuestions()
+    : getDummyQuestions(false);
+  console.log(selectedTags);
   const filteredquestions: MCQuestion[] = filterQuestionsByTags(
     questions,
     selectedTags,

--- a/src/components/MCQ/MCQTagOptions.vue
+++ b/src/components/MCQ/MCQTagOptions.vue
@@ -20,8 +20,9 @@ import type { SelectedTags } from "@/types/MCQ";
 import { getUniquePropertyValues } from "../QuestionStore";
 import { getAllQuestions, getDummyQuestions } from "../DataAccessLayer";
 import FilterCheckbox from "../FilterCheckbox.vue";
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 
+const emit = defineEmits(["update:selectedTags", "dummyDataStatus"]);
 // If dummy data is not provided as a prop, the getAllQuestions() will be used from DAL instead
 const { dummyData } = defineProps<{ dummyData?: { random: boolean } }>();
 
@@ -30,12 +31,15 @@ const tagSet = dummyData
   : getAllQuestions().flatMap((question) => question.tags);
 
 const filterSet: SelectedTags = getUniquePropertyValues(tagSet);
-const emit = defineEmits(["update:selectedTags"]);
 
 const selectedTags = ref<SelectedTags>({
   course: [],
   subject: [],
   system: [],
+});
+
+onMounted(() => {
+  emit("dummyDataStatus", dummyData ? false : true);
 });
 
 const modifySelectedTags = (

--- a/src/components/MCQ/MCQTagOptions.vue
+++ b/src/components/MCQ/MCQTagOptions.vue
@@ -23,6 +23,7 @@ import FilterCheckbox from "../FilterCheckbox.vue";
 import { ref } from "vue";
 const tagSet = getAllQuestions().flatMap((question) => question.tags);
 const filterSet: SelectedTags = getUniquePropertyValues(tagSet);
+const emit = defineEmits(["update:selectedTags"]);
 
 const selectedTags = ref<SelectedTags>({
   course: [],
@@ -39,6 +40,7 @@ const modifySelectedTags = (
     : selectedTags.value[category].filter(
         (selectedTopic) => selectedTopic !== topic,
       );
+  emit("update:selectedTags", selectedTags.value);
 };
 </script>
 

--- a/src/components/QuestionStore.ts
+++ b/src/components/QuestionStore.ts
@@ -1,4 +1,4 @@
-import { MCQuestion, tags } from "@/types/MCQ";
+import { MCQuestion, SelectedTags, tags } from "@/types/MCQ";
 import { getAllQuestions } from "./DataAccessLayer";
 
 /**
@@ -14,9 +14,11 @@ export const shuffleArray = (array: MCQuestion[]) => {
   return array;
 };
 
-export const getQuestionsRandomly = (count: number) => {
-  const allQuestions = getAllQuestions();
-  const shuffled = shuffleArray(allQuestions);
+export const getQuestionsRandomly = (
+  count: number,
+  questions: MCQuestion[],
+) => {
+  const shuffled = shuffleArray(questions);
   return shuffled.slice(0, count);
 };
 
@@ -42,11 +44,16 @@ export function getUniquePropertyValues(tagProps: tags[]) {
 
 export function filterQuestionsByTags(
   questions: MCQuestion[],
-  filterTags: tags,
+  selectedTags: SelectedTags,
 ): MCQuestion[] {
   return questions.filter((question) => {
-    return Object.entries(filterTags).every(([key, value]) => {
-      return question.tags[key as keyof tags] === value;
-    });
+    return (
+      (selectedTags.course.length === 0 ||
+        selectedTags.course.includes(question.tags.course)) &&
+      (selectedTags.subject.length === 0 ||
+        selectedTags.subject.includes(question.tags.subject)) &&
+      (selectedTags.system.length === 0 ||
+        selectedTags.system.includes(question.tags.system))
+    );
   });
 }

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <h1>VetCloud Smart Quiz</h1>
-    <MCQTagOptions :dummy-data="{ random: false }" />
+    <MCQTagOptions
+      :dummy-data="{ random: false }"
+      @update:selected-tags="handleSelectedTagsUpdate"
+      @dummy-data-status="handleDummyDataStatus"
+    />
     <div class="tags-display">
       <div class="tag-container course">
         <p class="tag-text">VETS2011</p>
@@ -37,6 +41,7 @@ import { ref } from "vue";
 import MCQTagOptions from "@components/MCQ/MCQTagOptions.vue";
 import { SelectedTags } from "@/types/MCQ";
 const questionAmount = ref<number>(0);
+const dummyDataProvided = ref<boolean>(false);
 const emit = defineEmits(["start-quiz"]);
 
 const selectedTags = ref<SelectedTags>({
@@ -49,10 +54,15 @@ const handleSelectedTagsUpdate = (updatedTags: SelectedTags) => {
   selectedTags.value = updatedTags;
 };
 
+const handleDummyDataStatus = (status: boolean) => {
+  dummyDataProvided.value = status;
+};
+
 const startQuiz = () => {
   emit("start-quiz", {
     questionAmount: questionAmount.value,
     selectedTags: selectedTags.value,
+    dummyBoolean: dummyDataProvided.value,
   });
 };
 </script>

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1>VetCloud Smart Quiz</h1>
-    <MCQTagOptions />
+    <MCQTagOptions @update:selected-tags="handleSelectedTagsUpdate" />
     <div class="tags-display">
       <div class="tag-container course">
         <p class="tag-text">VETS2011</p>
@@ -35,11 +35,25 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import MCQTagOptions from "@components/MCQ/MCQTagOptions.vue";
+import { SelectedTags } from "@/types/MCQ";
 const questionAmount = ref<number>(0);
 const emit = defineEmits(["start-quiz"]);
 
+const selectedTags = ref<SelectedTags>({
+  course: [],
+  subject: [],
+  system: [],
+});
+
+const handleSelectedTagsUpdate = (updatedTags: SelectedTags) => {
+  selectedTags.value = updatedTags;
+};
+
 const startQuiz = () => {
-  emit("start-quiz", questionAmount.value);
+  emit("start-quiz", {
+    questionAmount: questionAmount.value,
+    selectedTags: selectedTags.value,
+  });
 };
 </script>
 

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -2,7 +2,6 @@
   <div>
     <h1>VetCloud Smart Quiz</h1>
     <MCQTagOptions
-      :dummy-data="{ random: false }"
       @update:selected-tags="handleSelectedTagsUpdate"
       @dummy-data-status="handleDummyDataStatus"
     />
@@ -39,7 +38,9 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import MCQTagOptions from "@components/MCQ/MCQTagOptions.vue";
-import { SelectedTags } from "@/types/MCQ";
+import { MCQuestion, SelectedTags } from "@/types/MCQ";
+import { getDummyQuestions } from "./DataAccessLayer";
+import { filterQuestionsByTags } from "./QuestionStore";
 const questionAmount = ref<number>(0);
 const dummyDataProvided = ref<boolean>(false);
 const emit = defineEmits(["start-quiz"]);
@@ -52,6 +53,12 @@ const selectedTags = ref<SelectedTags>({
 
 const handleSelectedTagsUpdate = (updatedTags: SelectedTags) => {
   selectedTags.value = updatedTags;
+  const questions = getDummyQuestions(false);
+  const filteredquestions: MCQuestion[] = filterQuestionsByTags(
+    questions,
+    selectedTags.value,
+  );
+  console.log(filteredquestions.length);
 };
 
 const handleDummyDataStatus = (status: boolean) => {

--- a/tests/components/QuestionStore.test.ts
+++ b/tests/components/QuestionStore.test.ts
@@ -139,7 +139,7 @@ test("Filter questions by multiple courses and subjects", () => {
 
 test("Filter questions with multiple selections but no matches", () => {
   const filterTags: SelectedTags = {
-    course: ["VETS4044"],
+    course: ["VETS2022"],
     subject: ["Unknown"],
     system: ["Neurophysiology"],
   };

--- a/tests/components/QuestionStore.test.ts
+++ b/tests/components/QuestionStore.test.ts
@@ -4,6 +4,7 @@ import {
   getQuestionsRandomly,
   shuffleArray,
 } from "@components/QuestionStore";
+import { SelectedTags } from "@/types/MCQ";
 
 const questions = [
   {
@@ -67,17 +68,17 @@ vi.mock("@components/DataAccessLayer", () => {
 });
 
 test("Specify no questions and return with an empty array", () => {
-  const result = getQuestionsRandomly(0);
+  const result = getQuestionsRandomly(0, questions);
   expect(result).toEqual([]);
 });
 
 test("Specify questions more than provided", () => {
-  const result = getQuestionsRandomly(5);
+  const result = getQuestionsRandomly(5, questions);
   expect(result.length).toEqual(questions.length);
 });
 
 test("No question tags specified", () => {
-  const result = getQuestionsRandomly(7);
+  const result = getQuestionsRandomly(7, questions);
   expect(result).toEqual(questions);
 });
 
@@ -98,46 +99,51 @@ test("should not return the same array", () => {
   expect(shuffled).to.not.deep.equal(questions);
 });
 
-test("Filter questions by a specific course, subject, and system", () => {
-  const filterTags = {
-    course: "VETS2011",
-    subject: "Physiology",
-    system: "Neurophysiology",
+test("Filter questions by a specific course, subject, and system, allowing multiple selections", () => {
+  const filterTags: SelectedTags = {
+    course: ["VETS2011"],
+    subject: ["Physiology"],
+    system: ["Neurophysiology", "Cardiovascular"],
   };
   const filteredQuestions = filterQuestionsByTags(questions, filterTags);
-  expect(filteredQuestions.length).equal(2);
+  expect(filteredQuestions.length).toBe(3);
   expect(
     filteredQuestions.every(
       (question) =>
         question.tags.course === "VETS2011" &&
         question.tags.subject === "Physiology" &&
-        question.tags.system === "Neurophysiology",
+        (question.tags.system === "Neurophysiology" ||
+          question.tags.system === "Cardiovascular"),
     ),
   ).toBe(true);
 });
 
-test("Filter questions by course and subject, expecting multiple results", () => {
-  const filterTags = {
-    course: "VETS2011",
-    subject: "Physiology",
+test("Filter questions by multiple courses and subjects", () => {
+  const filterTags: SelectedTags = {
+    course: ["VETS2011", "VETS2022"],
+    subject: ["Physiology", "Anatomy"],
+    system: [],
   };
   const filteredQuestions = filterQuestionsByTags(questions, filterTags);
-  expect(filteredQuestions.length).equal(3);
+  expect(filteredQuestions.length).toBe(4);
   expect(
     filteredQuestions.every(
       (question) =>
-        question.tags.course === "VETS2011" &&
-        question.tags.subject === "Physiology",
+        (question.tags.course === "VETS2011" ||
+          question.tags.course === "VETS2022") &&
+        (question.tags.subject === "Physiology" ||
+          question.tags.subject === "Anatomy"),
     ),
   ).toBe(true);
 });
 
-test("Filter questions with no matching tags, expecting empty array", () => {
-  const filterTags = {
-    course: "VETS4044",
-    subject: "Unknown",
+test("Filter questions with multiple selections but no matches", () => {
+  const filterTags: SelectedTags = {
+    course: ["VETS4044"],
+    subject: ["Unknown"],
+    system: ["Neurophysiology"],
   };
   const filteredQuestions = filterQuestionsByTags(questions, filterTags);
-  expect(filteredQuestions.length).equal(0);
+  expect(filteredQuestions.length).toBe(0);
   expect(filteredQuestions).toEqual([]);
 });


### PR DESCRIPTION
the filtering functionality have been implemented. Users can easily select one or more attributes—such as course, subject, or system—from the filtering UI, and the system will dynamically update the list of quizzes to only show those that match the selected criteria
for manual testing:
1-If you want to test data based on `question-data.json` you need to remove the `dummy-data` prop from `MCQTagOptions` in `StartPage` (just delete it)
2- If you want a static data or random generated data just change the `random property` condition in `StartPage`
for code testing : 
run the command:
`yarn run test`