### PR TITLE
Story/vethub 77

### DIFF
--- a/data/question-data.json
+++ b/data/question-data.json
@@ -1,3757 +1,3757 @@
 {
   "questions": [
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the given primary taste stimuli depend on G protein-coupled receptors to depolarise the cell?",
-          "optionsList": [
-              {
-                  "optionValue": "Bitter and sweet",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Sour and sweet",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Salty and sour",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Salty and bitter",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "64ba560447d01bfdcb099e7f"
-          },
-          "label": "Taste Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the given primary taste stimuli are triggered by ions in the saliva?",
-          "optionsList": [
-              {
-                  "optionValue": "Bitter and sweet",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Sour and sweet",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Salty and sour",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Salty and bitter",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "64ba560447d01bfdcb099e80"
-          },
-          "label": "Taste Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which cranial nerve contains sensory neurons that contribute to the gag reflex?",
-          "optionsList": [
-              {
-                  "optionValue": "Facial nerve (CN VII)",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Glossopharyngeal nerve (CN IX)",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Vagus nerve (CN X)",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Hypoglossal nerve (CN XII)",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "64ba560447d01bfdcb099e81"
-          },
-          "label": "Taste Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Binding of an odorant to an odorant receptor on olfactory cells results in which of the following?",
-          "optionsList": [
-              {
-                  "optionValue": "Inflow of calcium",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Inflow of chloride",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Outflow of calcium",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Outflow of calcium and sodium",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "64ba560447d01bfdcb099e82"
-          },
-          "label": "Smell Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a864c71f1df2110df1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "What is the mechanism of smell transduction via the olfactory nerve?",
-          "optionsList": [
-              {
-                  "optionValue": "Tyrosine kinase-mediated",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "G protein-mediated cGMP activation",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "G protein-mediated cAMP activation",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Interaction of potassium and chloride",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "64ba560447d01bfdcb099e83"
-          },
-          "label": "Smell Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a864c71f1df2110df1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>The membrane potential is due to:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Na<sup>+</sup> diffusion in, K<sup>+</sup> diffusion out, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Na<sup>+</sup> diffusion out, K<sup>+</sup> diffusion in, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Na<sup>+</sup> diffusion out, K<sup>+</sup> diffusion out, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3af"
-          },
-          "label": "Neurons and the Resting Membrane Potential Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which part of a neuron receives information from surrounding cells?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Axon</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Presynaptic terminal</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Cell body</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Dendrite</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Myelin</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3ae"
-          },
-          "label": "Neurons and the Resting Membrane Potential Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Action potentials are transmitted along which part of a neuron?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Axon</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Pre-synaptic terminal</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Cell body</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Dendrite</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Myelin</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b0"
-          },
-          "label": "Neurons and the Resting Membrane Potential Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>The resting membrane potential of a mammalian neuron is:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>&minus;55 mV</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>0 mV</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>70 mV</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>&minus;70 mV</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b1"
-          },
-          "label": "Neurons and the Resting Membrane Potential Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements regarding action potentials is TRUE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Multiple depolarising events minimises the chance of action potential generation</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Reaching the subthreshold level does not stimulate the post-synaptic membrane</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Threshold event generates an action potential</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Reaching the subthreshold level is enough to generate an action potential</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Depolarised synaptic membrane is more negative than the hyperpolarised membrane</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b3"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following would NOT be possible occurrences when signal build-up occurs?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>They can reach action potential as a result of EPSP</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>IPSP can hyperpolarise the membrane</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>They can reach action potential as a result of IPSP</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>An action potential will be reached if the number of EPSP &gt; IPSP</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b4"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>When is it impossible to generate an action potential?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Absolute refractory period</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Relative refractory period</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sodium conductance</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>EPSPs after IPSPs</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Hyperpolarised state</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b5"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 6",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What happens when an IPSP is generated after EPSP?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>The membrane is more depolarised</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The effect of the subthreshold is enhanced</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Action potential is reached</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>A threshold event takes place</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The membrane is hyperpolarised</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b2"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What is the term used to describe an action potential that &ldquo;jumps&rdquo; from one node of Ranvier to another?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>EPSP conduction</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Saltatory conduction</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Myelinated conduction</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>IPSP conduction</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b6"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What happens when the membrane potential goes below &minus;70 mV?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Potassium conductance leads to potassium equilibrium potential</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Sodium equilibrium potential is reached</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sodium conductance causes depolarisation</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sodium conductance leads to potassium equilibrium potential</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The membrane is depolarised</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b7"
-          },
-          "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 5",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following types of glial cells myelinate neurons in the peripheral nervous system?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Ependymal cells</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Schwann cells</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Muller cells</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Oligodendrocytes</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b9"
-          },
-          "label": "Glial Cells and the Myelin Sheath Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214413464c71f1df2110d07"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is an attribute of ependymal cells?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Repair processes</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Cerebrospinal fluid synthesis</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Delivering nutrients</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Recycling of neurotransmitters</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Maintenance of terminal environment</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6603b47102442e7abcdda3b8"
-          },
-          "label": "Glial Cells and the Myelin Sheath Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214413464c71f1df2110d07"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements is TRUE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Electrical synapses are mediated by neurotransmitters</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Connexons are ion channels connecting 2 adjacent cells,&nbsp;and their opening is modulated by intracellular K<sup>+</sup> concentration</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Neurotransmitter molecules are stored in vesicles in the pre-synaptic terminal</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>The synaptic cleft in an electrical synapse is 20&ndash;40 nm wide</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fa8"
-          },
-          "label": "The Synapse and Neurotransmission Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d3a64c71f1df2110d15"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>During chemical neurotransmission, Ca<sup>2+</sup>&nbsp;ions are necessary for:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Binding the transmitter with the post-synaptic receptor</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Facilitating diffusion of the transmitter to the post-synaptic membrane</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Fusing the pre-synaptic vesicle with the pre-synaptic membrane, thus releasing the transmitter</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Metabolising the transmitter within the pre-synaptic vesicle</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fa9"
-          },
-          "label": "The Synapse and Neurotransmission Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d3a64c71f1df2110d15"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Depending on the pre-synaptic neurotransmitter released and the post-synaptic receptor activated, the post-synaptic membrane can either be depolarised or hyperpolarised. Which of the following statements is FALSE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Neurotransmitter binding to metabotropic receptors causes a conformational change in pore proteins</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "The action of metabotropic receptors is slower than ionotropic receptors",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Neurotransmitter binding to metabotropic receptors causes a conformational change, activating a signal transduction pathway",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "An example of an ionotropic receptor is the nicotinic acetylcholine receptor",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86faa"
-          },
-          "label": "Neurotransmitter Receptors Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "&gamma;-aminobutyric acid (GABA) is a rapidly acting neurotransmitter. You would expect the response on the post-synaptic membrane to be:",
-          "optionsList": [
-              {
-                  "optionValue": "Excitation due to opening of chloride channels",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hyperpolarisation due to blocking of sodium channels",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hyperpolarisation due to opening of chloride channels",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Excitation due to opening of sodium channels",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fab"
-          },
-          "label": "Neurotransmitter Receptors Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Nicotine (mimics acetylcholine) can bind to nicotinic cholinergic receptors. You would expect the response on the post-synaptic membrane to be:",
-          "optionsList": [
-              {
-                  "optionValue": "Excitation due to opening of chloride channels",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hyperpolarisation due to blocking of sodium channels",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hyperpolarisation due to opening of chloride channels",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Excitation due to opening of sodium channels",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fac"
-          },
-          "label": "Neurotransmitter Receptors Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements is TRUE with regard to the termination of the synaptic action at the neuromuscular junction?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>The re-uptake of intact acetylcholine molecules into the motor neuron terminal is responsible</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Diffusion of acetylcholine away from the synapse is solely responsible</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Acetylcholinesterase rapidly breaks down acetylcholine into choline and acetate</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Dissociation of acetylcholine from the muscarinic receptor, after binding for several seconds, is solely responsible</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fad"
-          },
-          "label": "The Neuromuscular Junction Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d7064c71f1df2110d17"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>At the neuromuscular junction, Ca<sup>2+</sup>&nbsp;ions are necessary for:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Binding the transmitter with the post-synaptic receptor</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Facilitating diffusion of the transmitter to the post-synaptic membrane</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Splitting the neurotransmitter in the synaptic cleft, deactivating the transmitter</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Fusing the pre-synaptic vesicle with the pre-synaptic membrane, thus releasing the transmitter</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Metabolising the transmitter within the pre-synaptic vesicle</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fae"
-          },
-          "label": "The Neuromuscular Junction Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d7064c71f1df2110d17"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements is INCORRECT?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>The muscle fibre and neuronal cell membranes are similar because they both have a resting membrane potential</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>A whole muscle, such as the semitendinosus muscle, can be made to contract more forcefully by increasing the number of motor units contracting</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The muscle cell membrane transmits action potentials by saltatory conduction</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>The shortening of a skeletal muscle during contraction is caused by the sliding together of actin and myosin filaments</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86faf"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements regarding the process of co-activation is FALSE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Intrafusal fibres receive motor innervation via &gamma;&nbsp;motor neurons</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>&gamma; motor neurons&nbsp;maintain the relative length of the muscle spindle, to the main muscle during contraction and relaxation</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>When muscle fibres contract, the muscle spindle shortens and the rate of action potentials in the afferent fibre increases</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>The purpose of maintaining muscle spindle tension is so that sensory information regarding changes in muscle length can still be signalled</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb0"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements regarding Golgi tendon organs is FALSE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Golgi tendon organs are located in the muscular tendinous junctions</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Goldi tendon organs provide sensory information regarding muscle stretch</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Golgi tendon organs are innervated by Ib sensory afferents</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Golgi tendon organs provide sensory information regarding muscle tension</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb1"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 5",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What class of muscle nerve fibre associated with muscle spindles provides sensory input regarding the amount the muscle has stretched?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>&alpha;</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>&gamma;</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Ia</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Ib</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>II</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb2"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What class of muscle nerve fibre associated with muscle spindles fires quickly, and responds to a change in length?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>&alpha;</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>&gamma;</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Ia</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Ib</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>II</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb3"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Tension is sensed by the Golgi tendon organ. Which of the following statements describes what happens next?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &alpha; motor neuron to decrease forced output</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &gamma; motor neuron to decrease forced output</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &gamma; motor neuron to decrease forced output</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &alpha; motor neuron to increase forced output</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb4"
-          },
-          "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 6",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements best describes the pain withdrawal reflex?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>A noxious stimulus results in inhibition of the flexor muscles and stimulation of the extensor muscles in the affected limb, and stimulation of the flexor muscles and inhibition of the extensor muscles in the contralateral limb</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>A noxious stimulus results in stimulation of the flexor muscles, and stimulation of the flexor muscles in the contralateral limb</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The pain withdrawal reflex results in contraction of the extensor muscles of the opposite limb to a painful stimulus, and relaxation of the flexor muscles in the affected limb</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>A noxious stimulus results in stimulation of the flexor muscles and&nbsp;inhibition of the extensor muscles in the affected limb, and inhibition of the flexor muscles and stimulation of the extensor muscles in the contralateral limb</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb5"
-          },
-          "label": "Pain Withdrawal Reflex Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846cd64c71f1df2110d24"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>A gross skeletal muscle belly can be instructed (by the central nervous system) to contract more forcefully by:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Causing more of its motor units to contract simultaneously</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Increasing the amount of acetylcholine released during each neuromuscular synaptic transmission</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Increasing the frequency of action potentials in the &alpha; motor neuron&rsquo;s axon</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Both a and c</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Both b and c</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb6"
-          },
-          "label": "Other Reflexes and the Motor Unit Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846db64c71f1df2110d25"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which mechanoreceptors are rapidly adapting and responsive to light touch?",
-          "optionsList": [
-              {
-                  "optionValue": "Pacini corpuscles",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Merkel disks",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Meissner corpuscles",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Ruffini endings",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb7"
-          },
-          "label": "Cutaneous Sensory Afferents Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following sensations are perceived by Merkel cells?",
-          "optionsList": [
-              {
-                  "optionValue": "Light pressure",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Crude touch",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Pain",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Vibration",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Temperature",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb8"
-          },
-          "label": "Cutaneous Sensory Afferents Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which mechanoreceptors sense vibration?",
-          "optionsList": [
-              {
-                  "optionValue": "Ruffini endings",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Pacinian corpuscles",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Hair follicle receptors",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Meissner corpuscles",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Merkel corpuscles",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fb9"
-          },
-          "label": "Cutaneous Sensory Afferents Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors respond to stretch and have a wide receptive field?",
-          "optionsList": [
-              {
-                  "optionValue": "Meissner corpuscles",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Ruffini endings",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Merkel cells",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Pacinian corpuscles",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hair cells",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fba"
-          },
-          "label": "Cutaneous Sensory Afferents Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Peripheral sensitisation of the nociceptors decreases the pain threshold. Which of the following substances sensitises the nociceptor endings?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Histamine</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Bradykinin</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Serotonin</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Potassium</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fbb"
-          },
-          "label": "Nociception  Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements regarding <strong>secondary</strong> hyperalgesia is FALSE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>The area surrounding a trauma can become tender</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Hypersensitivity is restricted to those nociceptors directly exposed to the injured or inflamed tissue</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Secondary hyperalgesia can alter central nociceptive processing in the spinal cord</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Central sensitisation manifests as pain hypersensitivity</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fbc"
-          },
-          "label": "Nociception  Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Sensory nerve afferents can release substances that can cause pain. Which of the following substances would be the most likely to be derived from a sensory nerve?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Histamine</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Acetylcholine</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Hydrogen ions</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Substance P</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fbd"
-          },
-          "label": "Nociception  Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following processes is the cerebral cortex NOT involved in?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "Motor planning and execution",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Visual and auditory processing",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Somatosensory and spatial processing",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Helps provide smooth, coordinated body movement",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Learning and memory",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fbe"
-          },
-          "label": "Central Nervous System Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which sensory pathway does NOT pass through the thalamus?",
-          "optionsList": [
-              {
-                  "optionValue": "Proprioception",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Olfactory",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Vestibular",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Visual",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Auditory",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fbf"
-          },
-          "label": "Central Nervous System Question 5",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Where in the cortex does language comprehension take place?",
-          "optionsList": [
-              {
-                  "optionValue": "Wernicke&rsquo;s area",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Frontal lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Occipital lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Temporal lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Limbic system",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc0"
-          },
-          "label": "Central Nervous System Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which part of the cortex is responsible for visual processing?",
-          "optionsList": [
-              {
-                  "optionValue": "Broca&rsquo;s area",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Frontal lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Occipital lobe",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Temporal lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Limbic system",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc1"
-          },
-          "label": "Central Nervous System Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "The limbic system is the part of the brain involved in which of the following?",
-          "optionsList": [
-              {
-                  "optionValue": "Voluntary motor activity",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Long-term memory",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Planning movement",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Higher-order visual processing",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc2"
-          },
-          "label": "Central Nervous System Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>A client calls because their dog is getting more and more fearful when walking in their neighbourhood, where there&rsquo;s a lot of road traffic. Last week, a car back-fired noisily in the driveway, right next to the dog. What is this an example of?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Classical conditioning</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Operant conditioning</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Habituation</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sensitisation</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc3"
-          },
-          "label": "Types of Learning Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "An animal trainer forms an association between a signal and the desired response by re-enforcing when this is achieved. For example, if a dog is barking at everyone that walks past a house, the trainer might start associating the word &ldquo;speak&rdquo; with the act of barking, by saying it every time the behaviour occurs. They then reinforce this with a treat. What is this an example of?",
-          "optionsList": [
-              {
-                  "optionValue": "Classical conditioning",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Operant conditioning",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Habituation",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Sensitisation",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc4"
-          },
-          "label": "Types of Learning Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is NOT a feature of habituation?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Desensitisation is related to a decrease in synaptic connectivity between sensory and motor neurons</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Strengthens the response to a potentially dangerous stimulus</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Decreases the amplitude of excitatory post-synaptic potentials</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Long-term habituation results in a structural change in synaptic connections (they decrease in number)</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc5"
-          },
-          "label": "Types of Learning Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>During short-term sensitisation of a stimulus/response pathway, which neurotransmitter is released from the axon terminal of the facilitating interneuron?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Dopamine</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Acetylcholine</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Glutamate</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Serotonin</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc6"
-          },
-          "label": "Neurological Steps to Learning Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Long-term sensitisation of a stimulus/response pathway will facilitate learning. Which of the following is NOT a feature of this process?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Increased number of action potentials along motor neurons&nbsp;to carry out movement</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Increased number of vesicles</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Increased number of vesicle release sites</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Increased number of pre-synaptic terminals</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc7"
-          },
-          "label": "Neurological Steps to Learning Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Long-term memories are&nbsp;stored in which part of the brain?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Occipital lobe</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Frontal lobe</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Hippocampus</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Wernicke&rsquo;s area</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc8"
-          },
-          "label": "Neurological Steps to Learning Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Where does the calcium bind in the thin filament?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Troponin C</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Troponin I</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Actin</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Tropomyosin</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Troponin T</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fc9"
-          },
-          "label": "Locomotion and Skeletal Muscle Organisation Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218633464c71f1df2110d4c"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is NOT a part of the thin filament?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Tropomyosin</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Actin</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Myosin heads</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Troponin C</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Troponin T</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fca"
-          },
-          "label": "Locomotion and Skeletal Muscle Organisation Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218633464c71f1df2110d4c"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following is activated by membrane depolarisation within the T-tubule of a skeletal myocyte?",
-          "optionsList": [
-              {
-                  "optionValue": "Ionotropic nicotinic receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Ryanodine receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "5HT receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Metabotropic nicotinic receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Dihydropyridine receptor",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fcb"
-          },
-          "label": "Muscle Fibre Contraction and Relaxation Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which neurotransmitter is responsible for the initiation of skeletal muscle contraction?",
-          "optionsList": [
-              {
-                  "optionValue": "GABA",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Norepinephrine",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Acetylcholine",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Glutamine",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Glycine",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fcc"
-          },
-          "label": "Muscle Fibre Contraction and Relaxation Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following allows for Ca<sup>2+</sup> to re-enter the sarcoplasmic reticulum and terminate the muscle contraction?",
-          "optionsList": [
-              {
-                  "optionValue": "The ionotropic nicotinic receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Sarco/endoplasmic reticulum calcium-ATPase (SERCA)",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "The muscarinic receptor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "The dihydropyridine receptor",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fcd"
-          },
-          "label": "Muscle Fibre Contraction and Relaxation Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is NOT a step in the muscle contraction process?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Tropomyosin covering the active site on actin</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>ADP molecule released during the power stroke</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>ATP binds to myosin causing the dissociation of the myosin head from the actin filament</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Hydrolysis of ATP allows for the cocking of the myosin head</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Calcium binds to troponin C, which moves tropomyosin from the active site on the actin filament</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fce"
-          },
-          "label": "Cross-bridge Cycling Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218635864c71f1df2110d4e"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following molecules is bound to myosin when the myosin head binds to the actin site?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>ADP</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>AMP</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>UDP</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>UTP</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>ATP</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fcf"
-          },
-          "label": "Cross-bridge Cycling Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218635864c71f1df2110d4e"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following contributes to planning movement?",
-          "optionsList": [
-              {
-                  "optionValue": "Brainstem",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Motor cortex",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Broca&rsquo;s area",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Cerebellum",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd0"
-          },
-          "label": "CNS Control of Movement Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218636964c71f1df2110d4f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "What is the brainstem&rsquo;s involvement in locomotion?",
-          "optionsList": [
-              {
-                  "optionValue": "Fine tunes locomotion",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Controls speed",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Plans voluntary movements",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Processes sensory feedback",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd1"
-          },
-          "label": "CNS Control of Movement Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218636964c71f1df2110d4f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following tracts provides sensory information from muscles to the CNS?",
-          "optionsList": [
-              {
-                  "optionValue": "Corticobulbar tract",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Spinocerebellar tract",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Lateral corticospinal tract",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Anterior corticospinal tract",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd2"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "The corticospinal tract has many functions. Which of the following is the MOST important function?",
-          "optionsList": [
-              {
-                  "optionValue": "Control of afferent inputs",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Spinal&nbsp;reflexes",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Motor&nbsp;neuron&nbsp;activity",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Mediation of voluntary distal movements",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd4"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "The corticobulbar tract is responsible for innervating muscles of the:",
-          "optionsList": [
-              {
-                  "optionValue": "Face, head, and neck",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Limbs",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Trunk, neck, and shoulders",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd5"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 5",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following statements regarding lower motor neurons is FALSE?",
-          "optionsList": [
-              {
-                  "optionValue": "They contact skeletal muscle, leading to muscle contraction",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "They travel in the corticospinal tract",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Their cell body is in the spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "They synapse with upper motor neurons",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd3"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "When the right forelimb is moved, where in the brain does the signal originate?",
-          "optionsList": [
-              {
-                  "optionValue": "Right cortex",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Cerebellum",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Medulla",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Left cortex",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd6"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 6",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following pathways is responsible for controlling the movement of limb muscles?",
-          "optionsList": [
-              {
-                  "optionValue": "Corticobulbar tract",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Spinocerebellar tract",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Lateral corticospinal tract",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Anterior corticospinal tract",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd7"
-          },
-          "label": "Inputs/Outputs to the Motor Cortex Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements regarding the basal ganglia is FALSE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>It doesn&rsquo;t receive spinal input</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It receives direct input from the cerebral cortex</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It modulates activity at the brainstem level</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>It is primarily associated with voluntary motor control</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd8"
-          },
-          "label": "Regulation of Voluntary Movement Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218639064c71f1df2110d51"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is NOT a function of the basal ganglia?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "Cognitive function",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Initiating movement",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Voluntary motor control",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Learning routine behaviours",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fd9"
-          },
-          "label": "Regulation of Voluntary Movement Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218639064c71f1df2110d51"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is considered a normal intraocular pressure in a dog?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>13 mmHg</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>26 mmHg</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>7 mmHg</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>5 mmHg</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>32 mmHg</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fda"
-          },
-          "label": "Structure and Function of the Eye Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Into which chamber of the eye does the ciliary body secrete fluid?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Posterior chamber</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Anterior chamber</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Vitreous chamber</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sclera chamber</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fdc"
-          },
-          "label": "Structure and Function of the Eye Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What is a blind spot in the eye?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Optic disc</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Cornea</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Choroid</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Fovea</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Retina</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fdd"
-          },
-          "label": "Structure and Function of the Eye Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following regions of the eye has the highest number of cone cells?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Optic disc</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Retina</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Choroid</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Fovea</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Zonule fibres</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fdb"
-          },
-          "label": "Structure and Function of the Eye Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>In which sequence does light enter and course through the eye?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Object &ndash; lens &ndash; aqueous humor &ndash; vitreous humor &ndash; retina</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Air &ndash; object &ndash; lens &ndash; retina</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Object &ndash; air &ndash; cornea &ndash; aqueous humor &ndash; lens &ndash; vitreous humor &ndash; retina</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Object &ndash; lens &ndash; air &ndash; retina &ndash; vitreous humor</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Lens &ndash; aqueous humor &ndash; cornea &ndash; air &ndash; object</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fde"
-          },
-          "label": "Pupil, Lens, and Humors Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>The structure in the eye responsible for the greatest refraction of light is the:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Cornea</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Aqueous humor</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Lens</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Vitreous humor</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fdf"
-          },
-          "label": "Pupil, Lens, and Humors Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What acts as an aperture to restrict light entry into the eye?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Lens</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Cornea</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Iris</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Sclera</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Retina</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe0"
-          },
-          "label": "Pupil, Lens, and Humors Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following would cause the lens to relax?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Taut zonule fibres</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Contraction of ciliary muscles</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Bright light</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Relaxation of ciliary muscles</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Object far away</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe1"
-          },
-          "label": "Pupil, Lens, and Humors Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>In an eye that is longer than normal, how is the image focussed incorrectly?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Light is not bent enough, leading to the image being focussed beyond the retina</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>The image is split into 2 focal points, creating blurred vision at all distances</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Light transmission is obscured</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Light rays from distant objects are focussed in front of the retina</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe2"
-          },
-          "label": "Errors of Refraction and Depth Perception Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Birds&nbsp;can tell relative distances using one eye. What method of depth perception do they use to do this?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Stereopsis</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Comparing the size of the image with a known object</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Moving parallax</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe3"
-          },
-          "label": "Errors of Refraction and Depth Perception Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>A dog with emmetropia will have:</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Less light transmission</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Normal vision</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Difficulty focussing on objects close by</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Blurry vision at all distances</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe4"
-          },
-          "label": "Errors of Refraction and Depth Perception Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Where are specialised photoreceptor response elements located in photoreceptor cells?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Inner segments</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Synaptic terminal</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Outer segment</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Basal cells</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Pigment epithelium</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe5"
-          },
-          "label": "Photoreception and Signal Convergence Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Sunlight changes the retinal component rhodopsin into which of the following configurations?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>All-<em>trans</em> retinal</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>11-<em>cis</em> retinal</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>3&rsquo; GMP retinal</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Transducin</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe6"
-          },
-          "label": "Photoreception and Signal Convergence Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following will contribute to the hyperpolarisation of the photoreceptor membrane?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Inactive phosphodiesterase</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Increase in cAMP</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Darkness</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sodium influx</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Decrease in cGMP</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe7"
-          },
-          "label": "Photoreception and Signal Convergence Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>What happens when light photons reach the retina?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Potassium channels open</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Potassium channels close</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Calcium channels open</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sodium channels close</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Sodium channels open</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe8"
-          },
-          "label": "Photoreception and Signal Convergence Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>When a dog sees an object in the distance and stares at it, which of the following is NOT a component of how they process the visual information to determine what it is?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>The colour of the object is determined by cones</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Stereopsis is used to determine how far away the object is</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Contraction of ciliary muscles</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Light rays from the object are focussed on the retina by accommodation of the lens</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fe9"
-          },
-          "label": "Vision - Impact on Animal Behaviour Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5bb64c71f1df2110d57"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "In which part of the ear does amplification of sound occur?",
-          "optionsList": [
-              {
-                  "optionValue": "Internal ear",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Incus",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Middle ear",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Malleus",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "External ear",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fea"
-          },
-          "label": "Hearing - Structure and Function Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which muscle dampens soundwaves when it contracts?",
-          "optionsList": [
-              {
-                  "optionValue": "Stapedius",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Tensor veli palatini",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Lateral pterygoid",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Medial pterygoid",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86feb"
-          },
-          "label": "Hearing - Structure and Function Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which chamber of the cochlea houses the Organ of Corti?",
-          "optionsList": [
-              {
-                  "optionValue": "Anterior chamber",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Middle chamber",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Upper chamber",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Lower chamber",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Posterior chamber",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fec"
-          },
-          "label": "Hearing - Structure and Function Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "A high pitch (<em>i.e.</em>, 12 kHz) sound stimulates hair cells closest to which cochlear-related structure?",
-          "optionsList": [
-              {
-                  "optionValue": "Oval window",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Apex of the basilar membrane",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Apex of the scala tympani",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Helicotrema",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fed"
-          },
-          "label": "Hearing - Hair Cells Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which ion enters hair cells after membrane depolarisation?",
-          "optionsList": [
-              {
-                  "optionValue": "Sodium",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Chloride",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Calcium",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Potassium",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Magnesium",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fee"
-          },
-          "label": "Hearing - Hair Cells Question 5",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "At the auditory nerve synapse level, depolarisation of the pre-synaptic membrane causes calcium influx which results in the release of which of the following substances from the synaptic vesicles?",
-          "optionsList": [
-              {
-                  "optionValue": "Acetylcholine",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Glutamate",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Adrenaline",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "GABA",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Serotonin",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fef"
-          },
-          "label": "Hearing - Hair Cells Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which structure senses soundwave frequency?",
-          "optionsList": [
-              {
-                  "optionValue": "Tympanic membrane",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Incus",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Stapes",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hair cells",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff0"
-          },
-          "label": "Hearing - Hair Cells Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following fluids in the ear has the highest potassium concentration?",
-          "optionsList": [
-              {
-                  "optionValue": "Plasma",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Endolymph",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Perilymph",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hair cell cytosol",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff1"
-          },
-          "label": "Hearing - Hair Cells Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following occurs during rotation of the head?",
-          "optionsList": [
-              {
-                  "optionValue": "The endolymph moves in the opposite direction of the rotation",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "The resting discharge rate does not change",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Some of the hair cells bend in the opposite direction, causing them to depolarise",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Some of the hair cells bend in the same direction, causing them to hyperpolarise",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "The endolymph moves in the same direction of the rotation.",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff2"
-          },
-          "label": "Balance - Vestibular Structure and Function Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "The hair cells get bent in one direction due to the presence of which of the following substances?",
-          "optionsList": [
-              {
-                  "optionValue": "Water",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Gelatinous material",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Plasma",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Gelatinous material and calcium stones",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Calcium stones",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff3"
-          },
-          "label": "Balance - Vestibular Structure and Function Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following is produced when hair cells are bent toward the kinocilium?",
-          "optionsList": [
-              {
-                  "optionValue": "Depolarisation",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Hyperpolarisation",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "No change",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Decreased conductance of potassium ions",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Decreased resting potential",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff4"
-          },
-          "label": "Balance - Vestibular Structure and Function Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following is NOT a part of the vestibular system?",
-          "optionsList": [
-              {
-                  "optionValue": "Saccule",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Semicircular canals",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Utricle",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Malleus",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff5"
-          },
-          "label": "Balance - Vestibular Structure and Function Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following can be a normal physiological process, as well as a pathologic one?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Ataxia</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Head tilt</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Nystagmus</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Altered mentation</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff6"
-          },
-          "label": "Vestibulospinal Tract and Vestibular Disease Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6237a6c664c71f1df2110d8f"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Where are the autonomic ganglia of the parasympathetic nervous system predominantly located?",
-          "optionsList": [
-              {
-                  "optionValue": "Far from the end organ",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Within the dorsal root of the spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Close to the spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Close to the end organ",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff7"
-          },
-          "label": "Structure and Function of the Autonomic Nervous System Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "What receptor is used in the autonomic ganglia in the parasympathetic nervous system to transduce their signals to the post-ganglionic nerve fibre?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic type 2",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Nicotinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 2",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff8"
-          },
-          "label": "Structure and Function of the Autonomic Nervous System Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following statements is TRUE regarding the length of the nerves in the parasympathetic nervous system?",
-          "optionsList": [
-              {
-                  "optionValue": "Post-synaptic nerves are long",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Pre-synaptic nerves are long",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Pre-synaptic nerves are short",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Length is not important for determining the action",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ff9"
-          },
-          "label": "Structure and Function of the Autonomic Nervous System Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Acetylcholine released from preganglionic neurons binds to which of the following receptors in the sympathetic nervous system?",
-          "optionsList": [
-              {
-                  "optionValue": "Nicotinic type 2",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 3",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 2",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ffa"
-          },
-          "label": "Structure and Function of the Autonomic Nervous System Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Where are the autonomic ganglia of the sympathetic nervous system predominantly located?",
-          "optionsList": [
-              {
-                  "optionValue": "Within the dorsal root of the spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Close to the spinal cord in the sympathetic chain",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Close to the end organ",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ffb"
-          },
-          "label": "Control of the Autonomic Nervous System Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which part of the central nervous system provides emotional input for the autonomic nervous system?",
-          "optionsList": [
-              {
-                  "optionValue": "Brainstem",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hypothalamus",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Limbic lobe",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Cerebral cortex",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ffc"
-          },
-          "label": "Control of the Autonomic Nervous System Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which part of the central nervous system is the main integration centre for the autonomic nervous system?",
-          "optionsList": [
-              {
-                  "optionValue": "Spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Brainstem",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Hypothalamus",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Limbic lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Cerebral cortex",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ffd"
-          },
-          "label": "Control of the Autonomic Nervous System Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "In which part of the central nervous system is the respiratory centre located?",
-          "optionsList": [
-              {
-                  "optionValue": "Spinal cord",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Brainstem",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Hypothalamus",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Limbic lobe",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Cerebral cortex",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86ffe"
-          },
-          "label": "Control of the Autonomic Nervous System Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors in the sympathetic system increases the heart rate when engaged?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-1 adrenergic",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Nicotinic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 2",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed86fff"
-          },
-          "label": "Effectors of the Autonomic Nervous System Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following nerves is an important component of the parasympathetic nervous system?",
-          "optionsList": [
-              {
-                  "optionValue": "Vagus",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Occulomotor",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Glossopharangeal",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Abducent",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Facial",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87001"
-          },
-          "label": "Effectors of the Autonomic Nervous System Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors induces vasoconstriction of blood vessels in the skin when engaged?",
-          "optionsList": [
-              {
-                  "optionValue": "Alpha adrenergic",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-1 adrenergic",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87000"
-          },
-          "label": "Effectors of the Autonomic Nervous System Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors of the sympathetic system induces bronchiole dilation in the lungs when engaged?",
-          "optionsList": [
-              {
-                  "optionValue": "Nicotinic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 2",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta adrenergic",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87002"
-          },
-          "label": "Effectors of the Autonomic Nervous System Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors in the sympathetic system contracts sphincters in the GI tract, slowing the passage of food?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha-1 adrenergic",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Nicotinic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 2",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87003"
-          },
-          "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors in the sympathetic system contracts the radial muscle in the iris, and what is its effect on the pupil?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic type 1; Dilates the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic; Dilates the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha-1 adrenergic; Constricts the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic; Constricts the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha-1 adrenergic; Dilates the pupil",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87005"
-          },
-          "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "Which of the following receptors in the parasympathetic system contracts the circular sphincter muscle in the iris, and what is its effect on the pupil?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic; Constricts the pupil",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic; Dilates the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic; Constricts the pupil",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha-1 adrenergic; Dilates the pupil",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87004"
-          },
-          "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "In a racehorse,&nbsp;which of the following receptors in the sympathetic system increases the production of sweat?",
-          "optionsList": [
-              {
-                  "optionValue": "Muscarinic type 1",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Beta-2 adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Alpha-1 adrenergic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Nicotinic",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "Muscarinic type 3",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0bdeb2b18699ed87006"
-          },
-          "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 4",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following structures is NOT a site where signal integration takes place?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>Brain nuclei</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Tracts</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>Ganglia</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Grey matter</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0beeb2b18699ed870d6"
-          },
-          "label": "Motor and Sensory Pathways, and the Reflex Arc Question 1",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following is a characteristic of a reflex?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>It requires conscious thought</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It does not require a stimulus to occur</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>Sensory information is carried into the spinal cord via the ventral root</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It is reproducible</p>",
-                  "optionCorrect": true
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0beeb2b18699ed870d7"
-          },
-          "label": "Motor and Sensory Pathways, and the Reflex Arc Question 3",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
-      },
-      {
-          "tags": {
-            "course": "VETS2011",
-            "subject": "Physiology",
-            "system": "Neurophysiology"
-          },
-          "statement": "<p>Which of the following statements about grey matter is TRUE?</p>",
-          "optionsList": [
-              {
-                  "optionValue": "<p>It forms the outer segment of the spinal cord</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It is found in tracts and nerves</p>",
-                  "optionCorrect": false
-              },
-              {
-                  "optionValue": "<p>It is a site of signal integration</p>",
-                  "optionCorrect": true
-              },
-              {
-                  "optionValue": "<p>It is a site where axons are grouped together</p>",
-                  "optionCorrect": false
-              }
-          ],
-          "_id": {
-              "$oid": "6539c0beeb2b18699ed870d8"
-          },
-          "label": "Motor and Sensory Pathways, and the Reflex Arc Question 2",
-          "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
-      }
+    {
+      "tags": {
+        "course": "VETS2013",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the given primary taste stimuli depend on G protein-coupled receptors to depolarise the cell?",
+      "optionsList": [
+        {
+          "optionValue": "Bitter and sweet",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Sour and sweet",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Salty and sour",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Salty and bitter",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "64ba560447d01bfdcb099e7f"
+      },
+      "label": "Taste Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiologytest",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the given primary taste stimuli are triggered by ions in the saliva?",
+      "optionsList": [
+        {
+          "optionValue": "Bitter and sweet",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Sour and sweet",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Salty and sour",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Salty and bitter",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "64ba560447d01bfdcb099e80"
+      },
+      "label": "Taste Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiologytest"
+      },
+      "statement": "Which cranial nerve contains sensory neurons that contribute to the gag reflex?",
+      "optionsList": [
+        {
+          "optionValue": "Facial nerve (CN VII)",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Glossopharyngeal nerve (CN IX)",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Vagus nerve (CN X)",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Hypoglossal nerve (CN XII)",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "64ba560447d01bfdcb099e81"
+      },
+      "label": "Taste Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a264c71f1df2110df0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Binding of an odorant to an odorant receptor on olfactory cells results in which of the following?",
+      "optionsList": [
+        {
+          "optionValue": "Inflow of calcium",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Inflow of chloride",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Outflow of calcium",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Outflow of calcium and sodium",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "64ba560447d01bfdcb099e82"
+      },
+      "label": "Smell Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a864c71f1df2110df1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "What is the mechanism of smell transduction via the olfactory nerve?",
+      "optionsList": [
+        {
+          "optionValue": "Tyrosine kinase-mediated",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "G protein-mediated cGMP activation",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "G protein-mediated cAMP activation",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Interaction of potassium and chloride",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "64ba560447d01bfdcb099e83"
+      },
+      "label": "Smell Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6242d73f64c71f1df2110ded/6242d7a864c71f1df2110df1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>The membrane potential is due to:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Na<sup>+</sup> diffusion in, K<sup>+</sup> diffusion out, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Na<sup>+</sup> diffusion out, K<sup>+</sup> diffusion in, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Na<sup>+</sup> diffusion out, K<sup>+</sup> diffusion out, the Na<sup>+</sup>/K<sup>+</sup> pump</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3af"
+      },
+      "label": "Neurons and the Resting Membrane Potential Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which part of a neuron receives information from surrounding cells?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Axon</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Presynaptic terminal</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Cell body</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Dendrite</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Myelin</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3ae"
+      },
+      "label": "Neurons and the Resting Membrane Potential Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Action potentials are transmitted along which part of a neuron?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Axon</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Pre-synaptic terminal</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Cell body</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Dendrite</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Myelin</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b0"
+      },
+      "label": "Neurons and the Resting Membrane Potential Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>The resting membrane potential of a mammalian neuron is:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>&minus;55 mV</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>0 mV</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>70 mV</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>&minus;70 mV</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b1"
+      },
+      "label": "Neurons and the Resting Membrane Potential Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements regarding action potentials is TRUE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Multiple depolarising events minimises the chance of action potential generation</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Reaching the subthreshold level does not stimulate the post-synaptic membrane</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Threshold event generates an action potential</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Reaching the subthreshold level is enough to generate an action potential</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Depolarised synaptic membrane is more negative than the hyperpolarised membrane</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b3"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following would NOT be possible occurrences when signal build-up occurs?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>They can reach action potential as a result of EPSP</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>IPSP can hyperpolarise the membrane</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>They can reach action potential as a result of IPSP</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>An action potential will be reached if the number of EPSP &gt; IPSP</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b4"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>When is it impossible to generate an action potential?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Absolute refractory period</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Relative refractory period</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sodium conductance</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>EPSPs after IPSPs</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Hyperpolarised state</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b5"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 6",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What happens when an IPSP is generated after EPSP?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>The membrane is more depolarised</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The effect of the subthreshold is enhanced</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Action potential is reached</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>A threshold event takes place</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The membrane is hyperpolarised</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b2"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What is the term used to describe an action potential that &ldquo;jumps&rdquo; from one node of Ranvier to another?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>EPSP conduction</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Saltatory conduction</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Myelinated conduction</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>IPSP conduction</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b6"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What happens when the membrane potential goes below &minus;70 mV?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Potassium conductance leads to potassium equilibrium potential</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Sodium equilibrium potential is reached</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sodium conductance causes depolarisation</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sodium conductance leads to potassium equilibrium potential</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The membrane is depolarised</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b7"
+      },
+      "label": "Post-synaptic Binding Outcomes, the Action Potential, and Saltatory Conduction Question 5",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following types of glial cells myelinate neurons in the peripheral nervous system?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Ependymal cells</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Schwann cells</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Muller cells</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Oligodendrocytes</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b9"
+      },
+      "label": "Glial Cells and the Myelin Sheath Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214413464c71f1df2110d07"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is an attribute of ependymal cells?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Repair processes</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Cerebrospinal fluid synthesis</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Delivering nutrients</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Recycling of neurotransmitters</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Maintenance of terminal environment</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6603b47102442e7abcdda3b8"
+      },
+      "label": "Glial Cells and the Myelin Sheath Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214413464c71f1df2110d07"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements is TRUE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Electrical synapses are mediated by neurotransmitters</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Connexons are ion channels connecting 2 adjacent cells,&nbsp;and their opening is modulated by intracellular K<sup>+</sup> concentration</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Neurotransmitter molecules are stored in vesicles in the pre-synaptic terminal</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>The synaptic cleft in an electrical synapse is 20&ndash;40 nm wide</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fa8"
+      },
+      "label": "The Synapse and Neurotransmission Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d3a64c71f1df2110d15"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>During chemical neurotransmission, Ca<sup>2+</sup>&nbsp;ions are necessary for:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Binding the transmitter with the post-synaptic receptor</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Facilitating diffusion of the transmitter to the post-synaptic membrane</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Fusing the pre-synaptic vesicle with the pre-synaptic membrane, thus releasing the transmitter</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Metabolising the transmitter within the pre-synaptic vesicle</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fa9"
+      },
+      "label": "The Synapse and Neurotransmission Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d3a64c71f1df2110d15"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Depending on the pre-synaptic neurotransmitter released and the post-synaptic receptor activated, the post-synaptic membrane can either be depolarised or hyperpolarised. Which of the following statements is FALSE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Neurotransmitter binding to metabotropic receptors causes a conformational change in pore proteins</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "The action of metabotropic receptors is slower than ionotropic receptors",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Neurotransmitter binding to metabotropic receptors causes a conformational change, activating a signal transduction pathway",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "An example of an ionotropic receptor is the nicotinic acetylcholine receptor",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86faa"
+      },
+      "label": "Neurotransmitter Receptors Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "&gamma;-aminobutyric acid (GABA) is a rapidly acting neurotransmitter. You would expect the response on the post-synaptic membrane to be:",
+      "optionsList": [
+        {
+          "optionValue": "Excitation due to opening of chloride channels",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hyperpolarisation due to blocking of sodium channels",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hyperpolarisation due to opening of chloride channels",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Excitation due to opening of sodium channels",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fab"
+      },
+      "label": "Neurotransmitter Receptors Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Nicotine (mimics acetylcholine) can bind to nicotinic cholinergic receptors. You would expect the response on the post-synaptic membrane to be:",
+      "optionsList": [
+        {
+          "optionValue": "Excitation due to opening of chloride channels",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hyperpolarisation due to blocking of sodium channels",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hyperpolarisation due to opening of chloride channels",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Excitation due to opening of sodium channels",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fac"
+      },
+      "label": "Neurotransmitter Receptors Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d5a64c71f1df2110d16"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements is TRUE with regard to the termination of the synaptic action at the neuromuscular junction?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>The re-uptake of intact acetylcholine molecules into the motor neuron terminal is responsible</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Diffusion of acetylcholine away from the synapse is solely responsible</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Acetylcholinesterase rapidly breaks down acetylcholine into choline and acetate</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Dissociation of acetylcholine from the muscarinic receptor, after binding for several seconds, is solely responsible</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fad"
+      },
+      "label": "The Neuromuscular Junction Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d7064c71f1df2110d17"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>At the neuromuscular junction, Ca<sup>2+</sup>&nbsp;ions are necessary for:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Binding the transmitter with the post-synaptic receptor</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Facilitating diffusion of the transmitter to the post-synaptic membrane</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Splitting the neurotransmitter in the synaptic cleft, deactivating the transmitter</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Fusing the pre-synaptic vesicle with the pre-synaptic membrane, thus releasing the transmitter</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Metabolising the transmitter within the pre-synaptic vesicle</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fae"
+      },
+      "label": "The Neuromuscular Junction Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183be064c71f1df2110d0f/62183d7064c71f1df2110d17"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements is INCORRECT?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>The muscle fibre and neuronal cell membranes are similar because they both have a resting membrane potential</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>A whole muscle, such as the semitendinosus muscle, can be made to contract more forcefully by increasing the number of motor units contracting</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The muscle cell membrane transmits action potentials by saltatory conduction</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>The shortening of a skeletal muscle during contraction is caused by the sliding together of actin and myosin filaments</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86faf"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements regarding the process of co-activation is FALSE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Intrafusal fibres receive motor innervation via &gamma;&nbsp;motor neurons</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>&gamma; motor neurons&nbsp;maintain the relative length of the muscle spindle, to the main muscle during contraction and relaxation</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>When muscle fibres contract, the muscle spindle shortens and the rate of action potentials in the afferent fibre increases</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>The purpose of maintaining muscle spindle tension is so that sensory information regarding changes in muscle length can still be signalled</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb0"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements regarding Golgi tendon organs is FALSE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Golgi tendon organs are located in the muscular tendinous junctions</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Goldi tendon organs provide sensory information regarding muscle stretch</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Golgi tendon organs are innervated by Ib sensory afferents</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Golgi tendon organs provide sensory information regarding muscle tension</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb1"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 5",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What class of muscle nerve fibre associated with muscle spindles provides sensory input regarding the amount the muscle has stretched?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>&alpha;</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>&gamma;</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Ia</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Ib</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>II</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb2"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What class of muscle nerve fibre associated with muscle spindles fires quickly, and responds to a change in length?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>&alpha;</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>&gamma;</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Ia</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Ib</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>II</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb3"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Tension is sensed by the Golgi tendon organ. Which of the following statements describes what happens next?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &alpha; motor neuron to decrease forced output</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &gamma; motor neuron to decrease forced output</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &gamma; motor neuron to decrease forced output</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Type Ib afferent is excited, synapses with an inhibitory interneuron to the &alpha; motor neuron to increase forced output</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb4"
+      },
+      "label": "Muscle Nerve Fibres, the Muscle Stretch, and GTO Reflexes Question 6",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846c064c71f1df2110d23"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements best describes the pain withdrawal reflex?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>A noxious stimulus results in inhibition of the flexor muscles and stimulation of the extensor muscles in the affected limb, and stimulation of the flexor muscles and inhibition of the extensor muscles in the contralateral limb</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>A noxious stimulus results in stimulation of the flexor muscles, and stimulation of the flexor muscles in the contralateral limb</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The pain withdrawal reflex results in contraction of the extensor muscles of the opposite limb to a painful stimulus, and relaxation of the flexor muscles in the affected limb</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>A noxious stimulus results in stimulation of the flexor muscles and&nbsp;inhibition of the extensor muscles in the affected limb, and inhibition of the flexor muscles and stimulation of the extensor muscles in the contralateral limb</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb5"
+      },
+      "label": "Pain Withdrawal Reflex Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846cd64c71f1df2110d24"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>A gross skeletal muscle belly can be instructed (by the central nervous system) to contract more forcefully by:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Causing more of its motor units to contract simultaneously</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Increasing the amount of acetylcholine released during each neuromuscular synaptic transmission</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Increasing the frequency of action potentials in the &alpha; motor neuron&rsquo;s axon</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Both a and c</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Both b and c</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb6"
+      },
+      "label": "Other Reflexes and the Motor Unit Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/621846db64c71f1df2110d25"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which mechanoreceptors are rapidly adapting and responsive to light touch?",
+      "optionsList": [
+        {
+          "optionValue": "Pacini corpuscles",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Merkel disks",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Meissner corpuscles",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Ruffini endings",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb7"
+      },
+      "label": "Cutaneous Sensory Afferents Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following sensations are perceived by Merkel cells?",
+      "optionsList": [
+        {
+          "optionValue": "Light pressure",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Crude touch",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Pain",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Vibration",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Temperature",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb8"
+      },
+      "label": "Cutaneous Sensory Afferents Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which mechanoreceptors sense vibration?",
+      "optionsList": [
+        {
+          "optionValue": "Ruffini endings",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Pacinian corpuscles",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Hair follicle receptors",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Meissner corpuscles",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Merkel corpuscles",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fb9"
+      },
+      "label": "Cutaneous Sensory Afferents Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors respond to stretch and have a wide receptive field?",
+      "optionsList": [
+        {
+          "optionValue": "Meissner corpuscles",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Ruffini endings",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Merkel cells",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Pacinian corpuscles",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hair cells",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fba"
+      },
+      "label": "Cutaneous Sensory Afferents Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218483164c71f1df2110d2f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Peripheral sensitisation of the nociceptors decreases the pain threshold. Which of the following substances sensitises the nociceptor endings?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Histamine</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Bradykinin</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Serotonin</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Potassium</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fbb"
+      },
+      "label": "Nociception  Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements regarding <strong>secondary</strong> hyperalgesia is FALSE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>The area surrounding a trauma can become tender</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Hypersensitivity is restricted to those nociceptors directly exposed to the injured or inflamed tissue</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Secondary hyperalgesia can alter central nociceptive processing in the spinal cord</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Central sensitisation manifests as pain hypersensitivity</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fbc"
+      },
+      "label": "Nociception  Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Sensory nerve afferents can release substances that can cause pain. Which of the following substances would be the most likely to be derived from a sensory nerve?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Histamine</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Acetylcholine</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Hydrogen ions</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Substance P</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fbd"
+      },
+      "label": "Nociception  Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bf664c71f1df2110d11/6218484164c71f1df2110d30"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following processes is the cerebral cortex NOT involved in?</p>",
+      "optionsList": [
+        {
+          "optionValue": "Motor planning and execution",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Visual and auditory processing",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Somatosensory and spatial processing",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Helps provide smooth, coordinated body movement",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Learning and memory",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fbe"
+      },
+      "label": "Central Nervous System Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which sensory pathway does NOT pass through the thalamus?",
+      "optionsList": [
+        {
+          "optionValue": "Proprioception",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Olfactory",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Vestibular",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Visual",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Auditory",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fbf"
+      },
+      "label": "Central Nervous System Question 5",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Where in the cortex does language comprehension take place?",
+      "optionsList": [
+        {
+          "optionValue": "Wernicke&rsquo;s area",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Frontal lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Occipital lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Temporal lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Limbic system",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc0"
+      },
+      "label": "Central Nervous System Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which part of the cortex is responsible for visual processing?",
+      "optionsList": [
+        {
+          "optionValue": "Broca&rsquo;s area",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Frontal lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Occipital lobe",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Temporal lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Limbic system",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc1"
+      },
+      "label": "Central Nervous System Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "The limbic system is the part of the brain involved in which of the following?",
+      "optionsList": [
+        {
+          "optionValue": "Voluntary motor activity",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Long-term memory",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Planning movement",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Higher-order visual processing",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc2"
+      },
+      "label": "Central Nervous System Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c2564c71f1df2110d37"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>A client calls because their dog is getting more and more fearful when walking in their neighbourhood, where there&rsquo;s a lot of road traffic. Last week, a car back-fired noisily in the driveway, right next to the dog. What is this an example of?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Classical conditioning</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Operant conditioning</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Habituation</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sensitisation</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc3"
+      },
+      "label": "Types of Learning Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "An animal trainer forms an association between a signal and the desired response by re-enforcing when this is achieved. For example, if a dog is barking at everyone that walks past a house, the trainer might start associating the word &ldquo;speak&rdquo; with the act of barking, by saying it every time the behaviour occurs. They then reinforce this with a treat. What is this an example of?",
+      "optionsList": [
+        {
+          "optionValue": "Classical conditioning",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Operant conditioning",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Habituation",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Sensitisation",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc4"
+      },
+      "label": "Types of Learning Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is NOT a feature of habituation?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Desensitisation is related to a decrease in synaptic connectivity between sensory and motor neurons</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Strengthens the response to a potentially dangerous stimulus</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Decreases the amplitude of excitatory post-synaptic potentials</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Long-term habituation results in a structural change in synaptic connections (they decrease in number)</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc5"
+      },
+      "label": "Types of Learning Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c3564c71f1df2110d38"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>During short-term sensitisation of a stimulus/response pathway, which neurotransmitter is released from the axon terminal of the facilitating interneuron?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Dopamine</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Acetylcholine</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Glutamate</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Serotonin</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc6"
+      },
+      "label": "Neurological Steps to Learning Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Long-term sensitisation of a stimulus/response pathway will facilitate learning. Which of the following is NOT a feature of this process?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Increased number of action potentials along motor neurons&nbsp;to carry out movement</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Increased number of vesicles</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Increased number of vesicle release sites</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Increased number of pre-synaptic terminals</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc7"
+      },
+      "label": "Neurological Steps to Learning Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Long-term memories are&nbsp;stored in which part of the brain?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Occipital lobe</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Frontal lobe</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Hippocampus</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Wernicke&rsquo;s area</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc8"
+      },
+      "label": "Neurological Steps to Learning Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bfc64c71f1df2110d12/62184c4564c71f1df2110d39"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Where does the calcium bind in the thin filament?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Troponin C</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Troponin I</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Actin</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Tropomyosin</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Troponin T</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fc9"
+      },
+      "label": "Locomotion and Skeletal Muscle Organisation Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218633464c71f1df2110d4c"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is NOT a part of the thin filament?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Tropomyosin</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Actin</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Myosin heads</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Troponin C</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Troponin T</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fca"
+      },
+      "label": "Locomotion and Skeletal Muscle Organisation Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218633464c71f1df2110d4c"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following is activated by membrane depolarisation within the T-tubule of a skeletal myocyte?",
+      "optionsList": [
+        {
+          "optionValue": "Ionotropic nicotinic receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Ryanodine receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "5HT receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Metabotropic nicotinic receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Dihydropyridine receptor",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fcb"
+      },
+      "label": "Muscle Fibre Contraction and Relaxation Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which neurotransmitter is responsible for the initiation of skeletal muscle contraction?",
+      "optionsList": [
+        {
+          "optionValue": "GABA",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Norepinephrine",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Acetylcholine",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Glutamine",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Glycine",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fcc"
+      },
+      "label": "Muscle Fibre Contraction and Relaxation Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following allows for Ca<sup>2+</sup> to re-enter the sarcoplasmic reticulum and terminate the muscle contraction?",
+      "optionsList": [
+        {
+          "optionValue": "The ionotropic nicotinic receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Sarco/endoplasmic reticulum calcium-ATPase (SERCA)",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "The muscarinic receptor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "The dihydropyridine receptor",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fcd"
+      },
+      "label": "Muscle Fibre Contraction and Relaxation Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218634464c71f1df2110d4d"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is NOT a step in the muscle contraction process?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Tropomyosin covering the active site on actin</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>ADP molecule released during the power stroke</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>ATP binds to myosin causing the dissociation of the myosin head from the actin filament</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Hydrolysis of ATP allows for the cocking of the myosin head</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Calcium binds to troponin C, which moves tropomyosin from the active site on the actin filament</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fce"
+      },
+      "label": "Cross-bridge Cycling Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218635864c71f1df2110d4e"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following molecules is bound to myosin when the myosin head binds to the actin site?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>ADP</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>AMP</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>UDP</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>UTP</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>ATP</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fcf"
+      },
+      "label": "Cross-bridge Cycling Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218635864c71f1df2110d4e"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following contributes to planning movement?",
+      "optionsList": [
+        {
+          "optionValue": "Brainstem",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Motor cortex",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Broca&rsquo;s area",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Cerebellum",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd0"
+      },
+      "label": "CNS Control of Movement Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218636964c71f1df2110d4f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "What is the brainstem&rsquo;s involvement in locomotion?",
+      "optionsList": [
+        {
+          "optionValue": "Fine tunes locomotion",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Controls speed",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Plans voluntary movements",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Processes sensory feedback",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd1"
+      },
+      "label": "CNS Control of Movement Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218636964c71f1df2110d4f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following tracts provides sensory information from muscles to the CNS?",
+      "optionsList": [
+        {
+          "optionValue": "Corticobulbar tract",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Spinocerebellar tract",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Lateral corticospinal tract",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Anterior corticospinal tract",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd2"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "The corticospinal tract has many functions. Which of the following is the MOST important function?",
+      "optionsList": [
+        {
+          "optionValue": "Control of afferent inputs",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Spinal&nbsp;reflexes",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Motor&nbsp;neuron&nbsp;activity",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Mediation of voluntary distal movements",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd4"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "The corticobulbar tract is responsible for innervating muscles of the:",
+      "optionsList": [
+        {
+          "optionValue": "Face, head, and neck",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Limbs",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Trunk, neck, and shoulders",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd5"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 5",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following statements regarding lower motor neurons is FALSE?",
+      "optionsList": [
+        {
+          "optionValue": "They contact skeletal muscle, leading to muscle contraction",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "They travel in the corticospinal tract",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Their cell body is in the spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "They synapse with upper motor neurons",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd3"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "When the right forelimb is moved, where in the brain does the signal originate?",
+      "optionsList": [
+        {
+          "optionValue": "Right cortex",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Cerebellum",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Medulla",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Left cortex",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd6"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 6",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following pathways is responsible for controlling the movement of limb muscles?",
+      "optionsList": [
+        {
+          "optionValue": "Corticobulbar tract",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Spinocerebellar tract",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Lateral corticospinal tract",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Anterior corticospinal tract",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd7"
+      },
+      "label": "Inputs/Outputs to the Motor Cortex Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218637d64c71f1df2110d50"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements regarding the basal ganglia is FALSE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>It doesn&rsquo;t receive spinal input</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It receives direct input from the cerebral cortex</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It modulates activity at the brainstem level</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>It is primarily associated with voluntary motor control</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd8"
+      },
+      "label": "Regulation of Voluntary Movement Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218639064c71f1df2110d51"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is NOT a function of the basal ganglia?</p>",
+      "optionsList": [
+        {
+          "optionValue": "Cognitive function",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Initiating movement",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Voluntary motor control",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Learning routine behaviours",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fd9"
+      },
+      "label": "Regulation of Voluntary Movement Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0264c71f1df2110d13/6218639064c71f1df2110d51"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is considered a normal intraocular pressure in a dog?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>13 mmHg</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>26 mmHg</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>7 mmHg</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>5 mmHg</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>32 mmHg</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fda"
+      },
+      "label": "Structure and Function of the Eye Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Into which chamber of the eye does the ciliary body secrete fluid?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Posterior chamber</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Anterior chamber</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Vitreous chamber</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sclera chamber</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fdc"
+      },
+      "label": "Structure and Function of the Eye Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What is a blind spot in the eye?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Optic disc</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Cornea</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Choroid</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Fovea</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Retina</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fdd"
+      },
+      "label": "Structure and Function of the Eye Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following regions of the eye has the highest number of cone cells?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Optic disc</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Retina</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Choroid</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Fovea</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Zonule fibres</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fdb"
+      },
+      "label": "Structure and Function of the Eye Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb55d64c71f1df2110d53"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>In which sequence does light enter and course through the eye?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Object &ndash; lens &ndash; aqueous humor &ndash; vitreous humor &ndash; retina</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Air &ndash; object &ndash; lens &ndash; retina</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Object &ndash; air &ndash; cornea &ndash; aqueous humor &ndash; lens &ndash; vitreous humor &ndash; retina</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Object &ndash; lens &ndash; air &ndash; retina &ndash; vitreous humor</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Lens &ndash; aqueous humor &ndash; cornea &ndash; air &ndash; object</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fde"
+      },
+      "label": "Pupil, Lens, and Humors Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>The structure in the eye responsible for the greatest refraction of light is the:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Cornea</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Aqueous humor</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Lens</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Vitreous humor</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fdf"
+      },
+      "label": "Pupil, Lens, and Humors Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What acts as an aperture to restrict light entry into the eye?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Lens</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Cornea</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Iris</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Sclera</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Retina</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe0"
+      },
+      "label": "Pupil, Lens, and Humors Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following would cause the lens to relax?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Taut zonule fibres</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Contraction of ciliary muscles</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Bright light</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Relaxation of ciliary muscles</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Object far away</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe1"
+      },
+      "label": "Pupil, Lens, and Humors Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb57364c71f1df2110d54"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>In an eye that is longer than normal, how is the image focussed incorrectly?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Light is not bent enough, leading to the image being focussed beyond the retina</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>The image is split into 2 focal points, creating blurred vision at all distances</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Light transmission is obscured</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Light rays from distant objects are focussed in front of the retina</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe2"
+      },
+      "label": "Errors of Refraction and Depth Perception Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Birds&nbsp;can tell relative distances using one eye. What method of depth perception do they use to do this?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Stereopsis</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Comparing the size of the image with a known object</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Moving parallax</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe3"
+      },
+      "label": "Errors of Refraction and Depth Perception Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>A dog with emmetropia will have:</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Less light transmission</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Normal vision</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Difficulty focussing on objects close by</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Blurry vision at all distances</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe4"
+      },
+      "label": "Errors of Refraction and Depth Perception Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb58864c71f1df2110d55"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Where are specialised photoreceptor response elements located in photoreceptor cells?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Inner segments</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Synaptic terminal</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Outer segment</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Basal cells</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Pigment epithelium</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe5"
+      },
+      "label": "Photoreception and Signal Convergence Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Sunlight changes the retinal component rhodopsin into which of the following configurations?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>All-<em>trans</em> retinal</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>11-<em>cis</em> retinal</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>3&rsquo; GMP retinal</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Transducin</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe6"
+      },
+      "label": "Photoreception and Signal Convergence Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following will contribute to the hyperpolarisation of the photoreceptor membrane?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Inactive phosphodiesterase</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Increase in cAMP</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Darkness</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sodium influx</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Decrease in cGMP</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe7"
+      },
+      "label": "Photoreception and Signal Convergence Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>What happens when light photons reach the retina?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Potassium channels open</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Potassium channels close</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Calcium channels open</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sodium channels close</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Sodium channels open</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe8"
+      },
+      "label": "Photoreception and Signal Convergence Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5aa64c71f1df2110d56"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>When a dog sees an object in the distance and stares at it, which of the following is NOT a component of how they process the visual information to determine what it is?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>The colour of the object is determined by cones</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Stereopsis is used to determine how far away the object is</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Contraction of ciliary muscles</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Light rays from the object are focussed on the retina by accommodation of the lens</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fe9"
+      },
+      "label": "Vision - Impact on Animal Behaviour Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183c0764c71f1df2110d14/621eb5bb64c71f1df2110d57"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "In which part of the ear does amplification of sound occur?",
+      "optionsList": [
+        {
+          "optionValue": "Internal ear",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Incus",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Middle ear",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Malleus",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "External ear",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fea"
+      },
+      "label": "Hearing - Structure and Function Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which muscle dampens soundwaves when it contracts?",
+      "optionsList": [
+        {
+          "optionValue": "Stapedius",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Tensor veli palatini",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Lateral pterygoid",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Medial pterygoid",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86feb"
+      },
+      "label": "Hearing - Structure and Function Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which chamber of the cochlea houses the Organ of Corti?",
+      "optionsList": [
+        {
+          "optionValue": "Anterior chamber",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Middle chamber",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Upper chamber",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Lower chamber",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Posterior chamber",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fec"
+      },
+      "label": "Hearing - Structure and Function Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac0d64c71f1df2110d82"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "A high pitch (<em>i.e.</em>, 12 kHz) sound stimulates hair cells closest to which cochlear-related structure?",
+      "optionsList": [
+        {
+          "optionValue": "Oval window",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Apex of the basilar membrane",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Apex of the scala tympani",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Helicotrema",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fed"
+      },
+      "label": "Hearing - Hair Cells Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which ion enters hair cells after membrane depolarisation?",
+      "optionsList": [
+        {
+          "optionValue": "Sodium",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Chloride",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Calcium",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Potassium",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Magnesium",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fee"
+      },
+      "label": "Hearing - Hair Cells Question 5",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "At the auditory nerve synapse level, depolarisation of the pre-synaptic membrane causes calcium influx which results in the release of which of the following substances from the synaptic vesicles?",
+      "optionsList": [
+        {
+          "optionValue": "Acetylcholine",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Glutamate",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Adrenaline",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "GABA",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Serotonin",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fef"
+      },
+      "label": "Hearing - Hair Cells Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which structure senses soundwave frequency?",
+      "optionsList": [
+        {
+          "optionValue": "Tympanic membrane",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Incus",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Stapes",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hair cells",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff0"
+      },
+      "label": "Hearing - Hair Cells Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following fluids in the ear has the highest potassium concentration?",
+      "optionsList": [
+        {
+          "optionValue": "Plasma",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Endolymph",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Perilymph",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hair cell cytosol",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff1"
+      },
+      "label": "Hearing - Hair Cells Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac1a64c71f1df2110d83"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following occurs during rotation of the head?",
+      "optionsList": [
+        {
+          "optionValue": "The endolymph moves in the opposite direction of the rotation",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "The resting discharge rate does not change",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Some of the hair cells bend in the opposite direction, causing them to depolarise",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Some of the hair cells bend in the same direction, causing them to hyperpolarise",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "The endolymph moves in the same direction of the rotation.",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff2"
+      },
+      "label": "Balance - Vestibular Structure and Function Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "The hair cells get bent in one direction due to the presence of which of the following substances?",
+      "optionsList": [
+        {
+          "optionValue": "Water",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Gelatinous material",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Plasma",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Gelatinous material and calcium stones",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Calcium stones",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff3"
+      },
+      "label": "Balance - Vestibular Structure and Function Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following is produced when hair cells are bent toward the kinocilium?",
+      "optionsList": [
+        {
+          "optionValue": "Depolarisation",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Hyperpolarisation",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "No change",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Decreased conductance of potassium ions",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Decreased resting potential",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff4"
+      },
+      "label": "Balance - Vestibular Structure and Function Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following is NOT a part of the vestibular system?",
+      "optionsList": [
+        {
+          "optionValue": "Saccule",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Semicircular canals",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Utricle",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Malleus",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff5"
+      },
+      "label": "Balance - Vestibular Structure and Function Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6232ac2c64c71f1df2110d84"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following can be a normal physiological process, as well as a pathologic one?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Ataxia</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Head tilt</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Nystagmus</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Altered mentation</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff6"
+      },
+      "label": "Vestibulospinal Tract and Vestibular Disease Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/6232abf264c71f1df2110d81/6237a6c664c71f1df2110d8f"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Where are the autonomic ganglia of the parasympathetic nervous system predominantly located?",
+      "optionsList": [
+        {
+          "optionValue": "Far from the end organ",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Within the dorsal root of the spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Close to the spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Close to the end organ",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff7"
+      },
+      "label": "Structure and Function of the Autonomic Nervous System Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "What receptor is used in the autonomic ganglia in the parasympathetic nervous system to transduce their signals to the post-ganglionic nerve fibre?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic type 2",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Nicotinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 2",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff8"
+      },
+      "label": "Structure and Function of the Autonomic Nervous System Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following statements is TRUE regarding the length of the nerves in the parasympathetic nervous system?",
+      "optionsList": [
+        {
+          "optionValue": "Post-synaptic nerves are long",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Pre-synaptic nerves are long",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Pre-synaptic nerves are short",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Length is not important for determining the action",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ff9"
+      },
+      "label": "Structure and Function of the Autonomic Nervous System Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Acetylcholine released from preganglionic neurons binds to which of the following receptors in the sympathetic nervous system?",
+      "optionsList": [
+        {
+          "optionValue": "Nicotinic type 2",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 3",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 2",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ffa"
+      },
+      "label": "Structure and Function of the Autonomic Nervous System Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc22d64c71f1df2110dae"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Where are the autonomic ganglia of the sympathetic nervous system predominantly located?",
+      "optionsList": [
+        {
+          "optionValue": "Within the dorsal root of the spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Close to the spinal cord in the sympathetic chain",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Close to the end organ",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ffb"
+      },
+      "label": "Control of the Autonomic Nervous System Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which part of the central nervous system provides emotional input for the autonomic nervous system?",
+      "optionsList": [
+        {
+          "optionValue": "Brainstem",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hypothalamus",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Limbic lobe",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Cerebral cortex",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ffc"
+      },
+      "label": "Control of the Autonomic Nervous System Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which part of the central nervous system is the main integration centre for the autonomic nervous system?",
+      "optionsList": [
+        {
+          "optionValue": "Spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Brainstem",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Hypothalamus",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Limbic lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Cerebral cortex",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ffd"
+      },
+      "label": "Control of the Autonomic Nervous System Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "In which part of the central nervous system is the respiratory centre located?",
+      "optionsList": [
+        {
+          "optionValue": "Spinal cord",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Brainstem",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Hypothalamus",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Limbic lobe",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Cerebral cortex",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86ffe"
+      },
+      "label": "Control of the Autonomic Nervous System Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc35e64c71f1df2110daf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors in the sympathetic system increases the heart rate when engaged?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-2 adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-1 adrenergic",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Nicotinic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 2",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed86fff"
+      },
+      "label": "Effectors of the Autonomic Nervous System Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following nerves is an important component of the parasympathetic nervous system?",
+      "optionsList": [
+        {
+          "optionValue": "Vagus",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Occulomotor",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Glossopharangeal",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Abducent",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Facial",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87001"
+      },
+      "label": "Effectors of the Autonomic Nervous System Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors induces vasoconstriction of blood vessels in the skin when engaged?",
+      "optionsList": [
+        {
+          "optionValue": "Alpha adrenergic",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Beta-2 adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-1 adrenergic",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87000"
+      },
+      "label": "Effectors of the Autonomic Nervous System Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors of the sympathetic system induces bronchiole dilation in the lungs when engaged?",
+      "optionsList": [
+        {
+          "optionValue": "Nicotinic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 2",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta adrenergic",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87002"
+      },
+      "label": "Effectors of the Autonomic Nervous System Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc37364c71f1df2110db0"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors in the sympathetic system contracts sphincters in the GI tract, slowing the passage of food?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-2 adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha-1 adrenergic",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Nicotinic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 2",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87003"
+      },
+      "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors in the sympathetic system contracts the radial muscle in the iris, and what is its effect on the pupil?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic type 1; Dilates the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-2 adrenergic; Dilates the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha-1 adrenergic; Constricts the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic; Constricts the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha-1 adrenergic; Dilates the pupil",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87005"
+      },
+      "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "Which of the following receptors in the parasympathetic system contracts the circular sphincter muscle in the iris, and what is its effect on the pupil?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic; Constricts the pupil",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "Beta-2 adrenergic; Dilates the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic; Constricts the pupil",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha-1 adrenergic; Dilates the pupil",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87004"
+      },
+      "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "In a racehorse,&nbsp;which of the following receptors in the sympathetic system increases the production of sweat?",
+      "optionsList": [
+        {
+          "optionValue": "Muscarinic type 1",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Beta-2 adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Alpha-1 adrenergic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Nicotinic",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "Muscarinic type 3",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0bdeb2b18699ed87006"
+      },
+      "label": "Effectors of the Autonomic Nervous System - GI Tract and Other Tissues Question 4",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/623bbfad64c71f1df2110dad/623bc38064c71f1df2110db1"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following structures is NOT a site where signal integration takes place?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>Brain nuclei</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Tracts</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>Ganglia</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Grey matter</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0beeb2b18699ed870d6"
+      },
+      "label": "Motor and Sensory Pathways, and the Reflex Arc Question 1",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following is a characteristic of a reflex?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>It requires conscious thought</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It does not require a stimulus to occur</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Sensory information is carried into the spinal cord via the ventral root</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It is reproducible</p>",
+          "optionCorrect": true
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0beeb2b18699ed870d7"
+      },
+      "label": "Motor and Sensory Pathways, and the Reflex Arc Question 3",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
+    },
+    {
+      "tags": {
+        "course": "VETS2011",
+        "subject": "Physiology",
+        "system": "Neurophysiology"
+      },
+      "statement": "<p>Which of the following statements about grey matter is TRUE?</p>",
+      "optionsList": [
+        {
+          "optionValue": "<p>It forms the outer segment of the spinal cord</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It is found in tracts and nerves</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>It is a site of signal integration</p>",
+          "optionCorrect": true
+        },
+        {
+          "optionValue": "<p>It is a site where axons are grouped together</p>",
+          "optionCorrect": false
+        }
+      ],
+      "_id": {
+        "$oid": "6539c0beeb2b18699ed870d8"
+      },
+      "label": "Motor and Sensory Pathways, and the Reflex Arc Question 2",
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62183bee64c71f1df2110d10/64005d36e322761352e0f0bf"
+    }
   ]
 }

--- a/src/components/FilterCheckbox.vue
+++ b/src/components/FilterCheckbox.vue
@@ -4,22 +4,27 @@
       v-for="[idx, topic] in Object.entries(topics)"
       :key="idx"
       class="filter-options"
+      :class="{ 'grey-out': getQuestionsnumByTags(topic, category) === '0' }"
     >
       <input
         :id="`${category}-${topic}-checkbox`"
         type="checkbox"
         :name="category"
         :value="topic"
+        :disabled="getQuestionsnumByTags(topic, category) === '0'"
         @change="onChecked($event)"
       />
       <label :for="`${category}-${topic}-checkbox`"
         >{{ topic }}
         <span
-          v-if="getQuestionsnumByTags(topic, category) !== null"
+          v-if="
+            getQuestionsnumByTags(topic, category) !== null &&
+            getQuestionsnumByTags(topic, category) !== '0'
+          "
           class="question-number"
           >{{ getQuestionsnumByTags(topic, category) }}</span
-        >
-      </label>
+        ></label
+      >
     </li>
   </ul>
 </template>
@@ -72,6 +77,11 @@ const getQuestionsnumByTags = (
 </script>
 
 <style scoped>
+.grey-out {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .question-number {
   border-radius: 10px;
   text-align: center;

--- a/src/components/FilterCheckbox.vue
+++ b/src/components/FilterCheckbox.vue
@@ -35,13 +35,14 @@ const { category, topics } = defineProps<{
   topics: string[];
 }>();
 const questionsQueue = useQuizStore();
-const topicsArray = Object.entries(topics);
+
 const questionsNumByTags = computed(() =>
-  topicsArray.map(([idx, topic]) => {
+  Object.entries(topics).map(([idx, topic]) => {
     const num = getQuestionsnumByTags(topic, category);
     return { idx, topic, num };
   }),
 );
+
 const onChecked = (event: Event) => {
   if (!(event.target instanceof HTMLInputElement))
     return console.error("Trying to click on non-input element");
@@ -50,6 +51,7 @@ const onChecked = (event: Event) => {
   const topic = event.target.value;
   questionsQueue.modifySelectedTags(event.target.checked, { category, topic });
 };
+
 const getQuestionsnumByTags = (
   topic: string,
   category: string,

--- a/src/components/FilterCheckbox.vue
+++ b/src/components/FilterCheckbox.vue
@@ -1,29 +1,24 @@
 <template>
   <ul>
     <li
-      v-for="[idx, topic] in Object.entries(topics)"
+      v-for="{ idx, num, topic } in questionsNumByTags"
       :key="idx"
       class="filter-options"
-      :class="{ 'grey-out': getQuestionsnumByTags(topic, category) === '0' }"
+      :class="{ 'grey-out': num === '0' }"
     >
       <input
         :id="`${category}-${topic}-checkbox`"
         type="checkbox"
         :name="category"
         :value="topic"
-        :disabled="getQuestionsnumByTags(topic, category) === '0'"
+        :disabled="num === '0'"
         @change="onChecked($event)"
       />
       <label :for="`${category}-${topic}-checkbox`"
         >{{ topic }}
-        <span
-          v-if="
-            getQuestionsnumByTags(topic, category) !== null &&
-            getQuestionsnumByTags(topic, category) !== '0'
-          "
-          class="question-number"
-          >{{ getQuestionsnumByTags(topic, category) }}</span
-        ></label
+        <span v-if="num !== null && num !== '0'" class="question-number">{{
+          num
+        }}</span></label
       >
     </li>
   </ul>
@@ -34,11 +29,19 @@ import { SelectedTags } from "@/types/MCQ";
 import { useQuizStore } from "@/store/QuizStore";
 import { getQuestionsBasedOnEnv } from "./DataAccessLayer";
 import { filterQuestionsByTags } from "./QuestionStore";
+import { computed } from "vue";
 const { category, topics } = defineProps<{
   category: string;
   topics: string[];
 }>();
 const questionsQueue = useQuizStore();
+const topicsArray = Object.entries(topics);
+const questionsNumByTags = computed(() =>
+  topicsArray.map(([idx, topic]) => {
+    const num = getQuestionsnumByTags(topic, category);
+    return { idx, topic, num };
+  }),
+);
 const onChecked = (event: Event) => {
   if (!(event.target instanceof HTMLInputElement))
     return console.error("Trying to click on non-input element");

--- a/tests/components/FilterCheckbox.test.ts
+++ b/tests/components/FilterCheckbox.test.ts
@@ -19,8 +19,8 @@ beforeEach(() => {
     },
   });
   const checkboxes = wrapper.findAll("input[type='checkbox']");
-  firstCheckbox = checkboxes[0];
-  secondCheckbox = checkboxes[1];
+  firstCheckbox = checkboxes[0] as DOMWrapper<HTMLInputElement>;
+  secondCheckbox = checkboxes[1] as DOMWrapper<HTMLInputElement>;
 });
 
 describe("FilterCheckbox.vue", () => {
@@ -55,7 +55,7 @@ it("Should disable and grey out checkboxes with no associated questions", async 
 it("Should display question count only for topics with available questions", async () => {
   const questionNumbers = wrapper.findAll(".question-number");
   expect(questionNumbers.length).toBe(1);
-  expect(questionNumbers[0].text()).toBe("115");
+  expect(isNaN(Number(questionNumbers[0].text()))).toBe(false);
 });
 
 it("Should update correctly when props change", async () => {

--- a/tests/components/FilterCheckbox.test.ts
+++ b/tests/components/FilterCheckbox.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import FilterCheckbox from "@/components/FilterCheckbox.vue";
 import { DOMWrapper, VueWrapper, mount } from "@vue/test-utils";
 import { useQuizStore } from "@/store/QuizStore";
@@ -8,6 +8,7 @@ let wrapper: VueWrapper;
 const category: string = "course";
 const topics: string[] = ["VETS2011", "VETS2012"];
 let firstCheckbox: Omit<DOMWrapper<HTMLInputElement>, "exists">;
+let secondCheckbox: Omit<DOMWrapper<HTMLInputElement>, "exists">;
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -18,7 +19,9 @@ beforeEach(() => {
       topics,
     },
   });
-  firstCheckbox = wrapper.get("input[type='checkbox']");
+  const checkboxes = wrapper.findAll("input[type='checkbox']");
+  firstCheckbox = checkboxes[0];
+  secondCheckbox = checkboxes[1];
 });
 
 describe("FilterCheckbox.vue", () => {
@@ -42,4 +45,25 @@ describe("FilterCheckbox.vue", () => {
 
     expect(firstCheckbox.element.checked).toBe(true);
   });
+});
+
+it("Should disable and grey out checkboxes with no associated questions", async () => {
+  //VETS2012 has no questions.
+  expect(secondCheckbox.attributes("disabled")).toBe("");
+  expect(wrapper.find(".grey-out").exists()).toBe(true);
+});
+
+it("Should display question count only for topics with available questions", async () => {
+  const questionNumbers = wrapper.findAll(".question-number");
+  expect(questionNumbers.length).toBe(1);
+  expect(questionNumbers[0].text()).toBe("115");
+});
+
+it("Should update correctly when props change", async () => {
+  const newTopics = ["VETS2013", "VETS2014"];
+  await wrapper.setProps({ topics: newTopics });
+
+  expect(wrapper.findAll("input[type='checkbox']").length).toBe(
+    newTopics.length,
+  );
 });

--- a/tests/components/MCQTagOptions.test.ts
+++ b/tests/components/MCQTagOptions.test.ts
@@ -20,7 +20,7 @@ describe("MCQTagOptions.vue", () => {
       },
     });
 
-    expect(wrapper.findAll(".filter-options").length).toBe(3);
+    expect(wrapper.findAll(".category").length).toBe(3);
   });
 
   it("Returns an empty array when input is empty", () => {


### PR DESCRIPTION
users navigating the filtering options should see check-boxes unrelated to the selected tags grayed out and set to an inactive state
for sample testing:
1. edit the question-data:
      -   set the first question course tag to "VETS2013"
      -  set the second question subject tag to "Physio"
2. run `yarn dev`
3. tick the VETS2013 box, you'll notice that Physio has been greyed out
for code testing : 
run the command:
`yarn run test`