### PR TITLE
story/VETHUB-86

### DIFF
--- a/src/components/FilterCheckbox.vue
+++ b/src/components/FilterCheckbox.vue
@@ -106,17 +106,30 @@ const getQuestionsnumByTags = (
 ul {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1rem;
 }
 @media screen and (max-width: 768px) {
   .filter-options {
     text-align: left;
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    align-items: center;
   }
   ul {
     display: flex;
+    flex-direction: column;
+    text-align: left;
     flex-wrap: wrap;
+    gap: 0.25rem;
+    margin: 0;
+    padding-left: clamp(10px, 5vw, 40px);
+  }
+  ul label {
+    font-size: 0.85rem;
+  }
+  ul input {
+    width: 8px;
+    height: 8px;
   }
 }
 </style>

--- a/src/components/FilterCheckbox.vue
+++ b/src/components/FilterCheckbox.vue
@@ -101,6 +101,7 @@ const getQuestionsnumByTags = (
   width: fit-content;
   font-weight: bolder;
   font-size: small;
+  margin-left: 2px;
 }
 
 ul {
@@ -122,7 +123,7 @@ ul {
     flex-wrap: wrap;
     gap: 0.25rem;
     margin: 0;
-    padding-left: clamp(10px, 5vw, 40px);
+    padding-left: clamp(10px, 5vw, 20px);
   }
   ul label {
     font-size: 0.85rem;
@@ -130,6 +131,9 @@ ul {
   ul input {
     width: 8px;
     height: 8px;
+  }
+  .question-number {
+    font-size: smaller;
   }
 }
 </style>

--- a/src/components/MCQ/MCQTagOptions.vue
+++ b/src/components/MCQ/MCQTagOptions.vue
@@ -44,9 +44,10 @@ label {
     /* text-align: center; */
   }
   .category > h2 {
-    padding-left: clamp(10px, 5vw, 42px);
+    padding-left: clamp(10px, 5vw, 18px);
     font-size: 1.25rem;
     margin-inline: clamp(0.1rem, 1.5vw, 0.25rem);
+    margin-bottom: 0.5rem;
   }
 }
 </style>

--- a/src/components/MCQ/MCQTagOptions.vue
+++ b/src/components/MCQ/MCQTagOptions.vue
@@ -41,7 +41,12 @@ label {
 
 @media screen and (max-width: 768px) {
   .filter {
-    text-align: center;
+    /* text-align: center; */
+  }
+  .category > h2 {
+    padding-left: clamp(10px, 5vw, 42px);
+    font-size: 1.25rem;
+    margin-inline: clamp(0.1rem, 1.5vw, 0.25rem);
   }
 }
 </style>

--- a/src/components/MCQ/MCQTagOptions.vue
+++ b/src/components/MCQ/MCQTagOptions.vue
@@ -40,11 +40,9 @@ label {
 }
 
 @media screen and (max-width: 768px) {
-  .filter {
-    /* text-align: center; */
-  }
   .category > h2 {
-    padding-left: clamp(10px, 5vw, 18px);
+    --responsive-padding-left: clamp(10px, 5vw, 18px);
+    padding-left: var(--responsive-padding-left);
     font-size: 1.25rem;
     margin-inline: clamp(0.1rem, 1.5vw, 0.25rem);
     margin-bottom: 0.5rem;

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -126,5 +126,10 @@ const checkMax = () => {
   #question-amount {
     margin-left: 0;
   }
+
+  .question-config-container {
+    --responsive-padding-left: clamp(10px, 5vw, 20px);
+    padding-left: var(--responsive-padding-left);
+  }
 }
 </style>

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -107,4 +107,24 @@ const checkMax = () => {
     43px 55px 87px #b8b8b8,
     -43px -55px 87px #ffffff;
 }
+
+@media screen and (max-width: 768px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+  .question-config-container {
+    font-size: 0.85rem;
+  }
+  .question-amount-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .question-amount-container input {
+    align-self: center;
+  }
+  #question-amount {
+    margin-left: 0;
+  }
+}
 </style>


### PR DESCRIPTION
```gitattributes
git fetch
git checkout story/VETHUB/86
```
no functionality changed but just in case `yarn test` passes all tests.
To test, go to `localhost` and go to dev tools. Go to the mobile responsive option and check the selection page is readable and usable in any device size.
![image](https://github.com/UQ-eLIPSE/crucible-components/assets/121275444/e53d05e4-36ab-44b5-ad7c-61f8e402fe0b)


Related ticket: https://elipse-uq.atlassian.net/jira/software/c/projects/VETHUB/boards/149?selectedIssue=VETHUB-86