### PR TITLE
Fixed the broken select option button

### DIFF
--- a/data/question-data-backend-sample.json
+++ b/data/question-data-backend-sample.json
@@ -41,34 +41,34 @@
         "subject: Physiology",
         "system: Nervous System"
       ],
-      "statement": "<p>Action potentials are transmitted along which part of a neuron?</p>",
+      "statement": "<p>AWhich of the following statements regarding action potentials is TRUE?</p>",
       "optionsList": [
         {
-          "optionValue": "<p>Axon</p>",
+          "optionValue": "<p>Multiple depolarising events minimises the chance of action potential generation</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Reaching the subthreshold level does not stimulate the post-synaptic membrane</p>",
+          "optionCorrect": false
+        },
+        {
+          "optionValue": "<p>Threshold event generates an action potential</p>",
           "optionCorrect": true
         },
         {
-          "optionValue": "<p>Pre-synaptic terminal</p>",
+          "optionValue": "<p>Depolarised synaptic membrane is more negative than the hyperpolarised membrane</p>",
           "optionCorrect": false
         },
         {
-          "optionValue": "<p>Cell body</p>",
-          "optionCorrect": false
-        },
-        {
-          "optionValue": "<p>Dendrite</p>",
-          "optionCorrect": false
-        },
-        {
-          "optionValue": "<p>Myelin</p>",
+          "optionValue": "<p>Reaching the subthreshold level is enough to generate an action potential</p>",
           "optionCorrect": false
         }
       ],
       "_id": {
-        "$oid": "6625c7c8c8259deb8c3af39e"
+        "$oid": "6615c7fb49fbda0108a9ac0b"
       },
       "label": "Placeholder label 1",
-      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd"
+      "link": "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03"
     },
     {
       "tags": [
@@ -76,27 +76,27 @@
         "subject: Physiology",
         "animal: Horse"
       ],
-      "statement": "<p>Action potentials are transmitted along which part of a neuron?</p>",
+      "statement": "<p>What happens when an IPSP is generated after EPSP?</p>",
       "optionsList": [
         {
-          "optionValue": "<p>Axon</p>",
+          "optionValue": "<p>The membrane is more depolarised</p>",
           "optionCorrect": true
         },
         {
-          "optionValue": "<p>Pre-synaptic terminal</p>",
+          "optionValue": "<p>The effect of the subthreshold is enhanced</p>",
           "optionCorrect": false
         },
         {
-          "optionValue": "<p>Cell body</p>",
+          "optionValue": "<p>Action potential is reached</p>",
           "optionCorrect": false
         },
         {
-          "optionValue": "<p>Dendrite</p>",
+          "optionValue": "<p>A threshold event takes place</p>",
           "optionCorrect": false
         },
         {
-          "optionValue": "<p>Myelin</p>",
-          "optionCorrect": false
+          "optionValue": "<p>The membrane is hyperpolarised</p>",
+          "optionCorrect": true
         }
       ],
       "_id": {

--- a/src/components/CrucibleComponent.vue
+++ b/src/components/CrucibleComponent.vue
@@ -21,7 +21,7 @@ const quizQuestions = ref(0);
 const questionsQueue = useQuizStore();
 const quizStarted = ref<boolean>(false);
 const questions = ref<MCQuestion[]>([]);
-// inject data from crucible parent here
+// Inject data from crucible parent here
 const apiData: DataApi = inject("$dataLink") as DataApi;
 
 onBeforeMount(() => {

--- a/src/components/MCQ/MCQQuestion.vue
+++ b/src/components/MCQ/MCQQuestion.vue
@@ -126,8 +126,7 @@ function getClassForTimedMode(_id: { $oid: string }, key: string): string {
     questionIndex,
     selectedValue,
   );
-  const answerString = String(answer);
-  if (answerString === key) {
+  if (String(answer) === key) {
     selectedOption.value = key;
     return "selected";
   }

--- a/src/components/MCQ/MCQQuestion.vue
+++ b/src/components/MCQ/MCQQuestion.vue
@@ -95,6 +95,7 @@ const resetQuestion = (_id: { $oid: string }) => {
   selectedOption.value = null;
 };
 const prevQuestion = () => {
+  selectedOption.value = null;
   emit("prevQuestion");
 };
 
@@ -125,8 +126,14 @@ function getClassForTimedMode(_id: { $oid: string }, key: string): string {
     questionIndex,
     selectedValue,
   );
-  return String(answer) === key ? "selected" : "";
+  const answerString = String(answer);
+  if (answerString === key) {
+    selectedOption.value = key;
+    return "selected";
+  }
+  return "";
 }
+
 function getClassForTutorMode(key: string, optionsList: MCQOptions[]): string {
   const option = optionsList[parseInt(key)];
   const isSelected = selectedOption.value === key;

--- a/src/components/question-data.ts
+++ b/src/components/question-data.ts
@@ -34,97 +34,99 @@ export const pluginQuestions = [
   {
     tags: ["course: VETS2012", "subject: Physiology", "system: Nervous System"],
     statement:
-      "<p>Action potentials are transmitted along which part of a neuron?</p>",
+      "<p>Which of the following statements regarding action potentials is TRUE?</p>",
     optionsList: [
       {
-        optionValue: "<p>Axon</p>",
+        optionValue:
+          "<p>Multiple depolarising events minimises the chance of action potential generation</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue:
+          "<p>Reaching the subthreshold level does not stimulate the post-synaptic membrane</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>Threshold event generates an action potential</p>",
         optionCorrect: true,
       },
       {
-        optionValue: "<p>Pre-synaptic terminal</p>",
+        optionValue:
+          "<p>Reaching the subthreshold level is enough to generate an action potential</p>",
         optionCorrect: false,
       },
       {
-        optionValue: "<p>Cell body</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Dendrite</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Myelin</p>",
+        optionValue:
+          "<p>Depolarised synaptic membrane is more negative than the hyperpolarised membrane</p>",
         optionCorrect: false,
       },
     ],
     _id: {
-      $oid: "6625c7c8c8259deb8c3af39e",
+      $oid: "6615c7fb49fbda0108a9ac0b",
     },
     label: "Placeholder label 1",
-    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd",
+    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03",
   },
   {
     tags: ["course: VETS2012", "subject: Physiology", "animal: Horse"],
-    statement:
-      "<p>Action potentials are transmitted along which part of a neuron?</p>",
+    statement: "<p>What happens when an IPSP is generated after EPSP?</p>",
     optionsList: [
       {
-        optionValue: "<p>Axon</p>",
+        optionValue: "<p>The membrane is more depolarised</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>The effect of the subthreshold is enhanced</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>Action potential is reached</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>A threshold event takes place</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>The membrane is hyperpolarised</p>",
         optionCorrect: true,
-      },
-      {
-        optionValue: "<p>Pre-synaptic terminal</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Cell body</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Dendrite</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Myelin</p>",
-        optionCorrect: false,
       },
     ],
     _id: {
-      $oid: "6625c7c8c8259deb8c3af39e",
+      $oid: "6615c7fb49fbda0108a9ac0a",
     },
     label: "Placeholder label 1",
-    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd",
+    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03",
   },
   {
     tags: ["course: VETS2012", "subject:Physiology", "animal:Horse"],
     statement:
-      "<p>Action potentials are transmitted along which part of a neuron?</p>",
+      "<p>Which of the following would NOT be possible occurrences when signal build-up occurs?</p>",
     optionsList: [
       {
-        optionValue: "<p>Axon</p>",
+        optionValue:
+          "<p>They can reach action potential as a result of EPSP</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue: "<p>IPSP can hyperpolarise the membrane</p>",
+        optionCorrect: false,
+      },
+      {
+        optionValue:
+          "<p>They can reach action potential as a result of IPSP</p>",
         optionCorrect: true,
       },
       {
-        optionValue: "<p>Pre-synaptic terminal</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Cell body</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Dendrite</p>",
-        optionCorrect: false,
-      },
-      {
-        optionValue: "<p>Myelin</p>",
+        optionValue:
+          "<p>An action potential will be reached if the number of EPSP &gt; IPSP</p>",
         optionCorrect: false,
       },
     ],
     _id: {
-      $oid: "6625c7c8c8259deb8c3af39e",
+      $oid: "6615c7fb49fbda0108a9ac0d",
     },
     label: "Placeholder label 1",
-    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd",
+    link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03",
   },
 ];


### PR DESCRIPTION
```gitattributes
git fetch
git checkout bug/VETHUB-133
```
The User now can see his selected option ticked at all times
to test:
`run yarn test`
This is what the user should see at all times:
![Screenshot from 2024-05-13 09-58-25](https://github.com/UQ-eLIPSE/crucible-components/assets/114811082/89e6cb48-e3b5-4e11-8b89-3c5900194f00)
ticket: https://elipse-uq.atlassian.net/browse/VETHUB-133?atlOrigin=eyJpIjoiYTVkOTNiZjc1N2EyNGMxYjlkYWU2ZDQwZTcwZDIzZDUiLCJwIjoiaiJ9