### PR TITLE
bug/VETHUB-123

### DIFF
--- a/src/components/CrucibleComponent.vue
+++ b/src/components/CrucibleComponent.vue
@@ -31,7 +31,7 @@ onBeforeMount(() => {
     ? getConvertedStaticData()
     : getAllQuestions(apiData.data.questions as DataMCQuestion[]);
   questionsQueue.allQs = questions.value;
-
+  console.log(questions.value.map((q) => q.tags));
   const allUniqueTags = getUniquePropertyValues(
     questions.value.map((q) => q.tags),
   );

--- a/src/components/CrucibleComponent.vue
+++ b/src/components/CrucibleComponent.vue
@@ -31,7 +31,6 @@ onBeforeMount(() => {
     ? getConvertedStaticData()
     : getAllQuestions(apiData.data.questions as DataMCQuestion[]);
   questionsQueue.allQs = questions.value;
-  console.log(questions.value.map((q) => q.tags));
   const allUniqueTags = getUniquePropertyValues(
     questions.value.map((q) => q.tags),
   );

--- a/src/components/QuestionStore.ts
+++ b/src/components/QuestionStore.ts
@@ -31,13 +31,7 @@ export function getUniquePropertyValues(tagProps: Tags[]) {
             acc[key] = new Set<string>();
           }
           const value = item[key];
-          if (Array.isArray(value)) {
-            // If is an array ad each element to the set
-            value.forEach((val) => acc[key].add(val));
-          } else {
-            // If it is an string just add it to the set
-            acc[key].add(value);
-          }
+          value.forEach((val) => acc[key].add(val));
         }
       });
       return acc;
@@ -53,7 +47,6 @@ export function getUniquePropertyValues(tagProps: Tags[]) {
     },
     {},
   );
-  console.log(result);
   return result;
 }
 
@@ -66,15 +59,9 @@ export function filterQuestionsByTags(
       if (!selectedTags[key].length) {
         return true;
       }
-
       const questionTag = question.tags[key];
-      // Check if questionTag is an array or a single string
-      if (Array.isArray(questionTag)) {
-        // Return true if any tag in the question's tag array is equal to any tag in the selected tags
+      if (questionTag) {
         return questionTag.some((tag) => selectedTags[key].includes(tag));
-      } else {
-        // Return true if the a question tag matches any tag in the selected tags
-        return selectedTags[key].includes(questionTag);
       }
     });
   });

--- a/src/components/question-data.ts
+++ b/src/components/question-data.ts
@@ -4,6 +4,7 @@ export const pluginQuestions = [
   {
     tags: [
       "course:vets2011",
+      "course:vets2011",
       "subject:physiology",
       "system:nervous_system",
       "234:tagvalue",
@@ -40,7 +41,12 @@ export const pluginQuestions = [
     link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214301b64c71f1df2110cfd",
   },
   {
-    tags: ["course: VETS2012", "subject: Physiology", "system: Nervous System"],
+    tags: [
+      "course: VETS2012",
+      "course:vets2016",
+      "subject: Physiology",
+      "system: Nervous System",
+    ],
     statement:
       "<p>Which of the following statements regarding action potentials is TRUE?</p>",
     optionsList: [

--- a/src/components/question-data.ts
+++ b/src/components/question-data.ts
@@ -82,12 +82,7 @@ export const pluginQuestions = [
     link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03",
   },
   {
-    tags: [
-      "course:vets2012",
-      "subject:physiology",
-      "animal:horse",
-      ": wrongtag",
-    ],
+    tags: ["course:vets2012", "subject:physiology", "animal:horse"],
     statement:
       "<p>Action potentials are transmitted along which part of a neuron?</p>",
     optionsList: [
@@ -181,7 +176,7 @@ export const pluginQuestions = [
     link: "https://vetshub.uqcloud.net/resource/5a0ba18d34cc363763e05e99/61a9ae14e04e3d5bffb26ef7/62142eee64c71f1df2110cf5/62142f2764c71f1df2110cf7/6214407964c71f1df2110d03",
   },
   {
-    tags: ["course: VETS2013", "subject:Physiology"],
+    tags: ["course: VETS2013", "course:vets2016", "subject:Physiology"],
     statement:
       "<p>Which of the following types of glial cells myelinate neurons in the peripheral nervous system?</p>",
     optionsList: [

--- a/src/types/MCQ.d.ts
+++ b/src/types/MCQ.d.ts
@@ -52,7 +52,7 @@ export interface QuestionState {
 }
 
 export interface Tags {
-  [key: string]: string;
+  [key: string]: string | string[];
 }
 
 export interface SelectedTags {

--- a/src/types/MCQ.d.ts
+++ b/src/types/MCQ.d.ts
@@ -52,7 +52,7 @@ export interface QuestionState {
 }
 
 export interface Tags {
-  [key: string]: string | string[];
+  [key: string]: string[];
 }
 
 export interface SelectedTags {

--- a/src/utils/UtilConversion.ts
+++ b/src/utils/UtilConversion.ts
@@ -15,15 +15,9 @@ export const convertTags = (tagsData: DataTags): Tags => {
 
     // Check if key exists
     if (acc[key]) {
-      // If the key exist and it's not already an array, convert it to array
-      if (typeof acc[key] === "string") {
-        acc[key] = [acc[key] as string];
-      }
-
-      (acc[key] as string[]).push(value);
+      acc[key] = [...acc[key], value];
     } else {
-      // If the key does not exist assign the value
-      acc[key] = value;
+      acc[key] = [value];
     }
     return acc;
   }, {});

--- a/src/utils/UtilConversion.ts
+++ b/src/utils/UtilConversion.ts
@@ -12,7 +12,19 @@ export const convertTags = (tagsData: DataTags): Tags => {
     if (!tag.includes(":")) return acc;
     let [key, value] = tag.split(":");
     [key, value] = [key.trim().toLowerCase(), getCorrectTagValues(value)];
-    acc[key] = value;
+
+    // Check if key exists
+    if (acc[key]) {
+      // If the key exist and it's not already an array, convert it to array
+      if (typeof acc[key] === "string") {
+        acc[key] = [acc[key] as string];
+      }
+
+      (acc[key] as string[]).push(value);
+    } else {
+      // If the key does not exist assign the value
+      acc[key] = value;
+    }
     return acc;
   }, {});
 };

--- a/tests/components/MCQTagOptions.test.ts
+++ b/tests/components/MCQTagOptions.test.ts
@@ -38,22 +38,22 @@ describe("MCQTagOptions.vue", () => {
   it("returns unique values for a given property", () => {
     const tags = [
       {
-        course: "VETS2011",
-        subject: "Physiology",
-        system: "Neurophysiology",
-        animal: "Horse",
+        course: ["VETS2011"],
+        subject: ["Physiology"],
+        system: ["Neurophysiology"],
+        animal: ["Horse"],
       },
       {
-        course: "VETS2011",
-        subject: "Anatomy",
-        system: "Cardiovascular",
-        animal: "Horse",
+        course: ["VETS2011"],
+        subject: ["Anatomy"],
+        system: ["Cardiovascular"],
+        animal: ["Horse"],
       },
       {
-        course: "VETS2012",
-        subject: "Physiology",
-        system: "Neurophysiology",
-        animal: "Horse",
+        course: ["VETS2012"],
+        subject: ["Physiology"],
+        system: ["Neurophysiology"],
+        animal: ["Horse"],
       },
     ];
 

--- a/tests/components/QuestionStore.test.ts
+++ b/tests/components/QuestionStore.test.ts
@@ -10,10 +10,10 @@ const questions = [
   {
     statement: "The question 1",
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Neurophysiology",
-      animal: "Horse",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Neurophysiology"],
+      animal: ["Horse"],
     },
     optionsList: [
       { optionValue: "Answer A Q1", optionCorrect: false },
@@ -24,10 +24,10 @@ const questions = [
   {
     statement: "The question 2",
     tags: {
-      course: "VETS2022",
-      subject: "Anatomy",
-      system: "Musculoskeletal",
-      animal: "Horse",
+      course: ["VETS2022"],
+      subject: ["Anatomy"],
+      system: ["Musculoskeletal"],
+      animal: ["Horse"],
     },
     optionsList: [
       { optionValue: "Answer A Q2", optionCorrect: false },
@@ -38,10 +38,10 @@ const questions = [
   {
     statement: "The question 3",
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Cardiovascular",
-      animal: "Horse",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Cardiovascular"],
+      animal: ["Horse"],
     },
     optionsList: [
       { optionValue: "Answer A Q3", optionCorrect: true },
@@ -52,10 +52,10 @@ const questions = [
   {
     statement: "The question 4",
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Neurophysiology",
-      animal: "Horse",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Neurophysiology"],
+      animal: ["Horse"],
     },
     optionsList: [
       { optionValue: "Answer A Q4", optionCorrect: true },
@@ -115,10 +115,10 @@ test("Filter questions by a specific course, subject, and system, allowing multi
   expect(
     filteredQuestions.every(
       (question) =>
-        question.tags.course === "VETS2011" &&
-        question.tags.subject === "Physiology" &&
-        (question.tags.system === "Neurophysiology" ||
-          question.tags.system === "Cardiovascular"),
+        question.tags.course[0] === "VETS2011" &&
+        question.tags.subject[0] === "Physiology" &&
+        (question.tags.system[0] === "Neurophysiology" ||
+          question.tags.system[0] === "Cardiovascular"),
     ),
   ).toBe(true);
 });
@@ -135,10 +135,10 @@ test("Filter questions by multiple courses and subjects", () => {
   expect(
     filteredQuestions.every(
       (question) =>
-        (question.tags.course === "VETS2011" ||
-          question.tags.course === "VETS2022") &&
-        (question.tags.subject === "Physiology" ||
-          question.tags.subject === "Anatomy"),
+        (question.tags.course[0] === "VETS2011" ||
+          question.tags.course[0] === "VETS2022") &&
+        (question.tags.subject[0] === "Physiology" ||
+          question.tags.subject[0] === "Anatomy"),
     ),
   ).toBe(true);
 });

--- a/tests/testSeeds.ts
+++ b/tests/testSeeds.ts
@@ -57,9 +57,9 @@ export const dataTest = [
 export const questionsData = [
   {
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Nervous System",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Nervous System"],
     },
     statement:
       "<p>Which of the following statements regarding action potentials is TRUE?</p>",
@@ -97,9 +97,9 @@ export const questionsData = [
   },
   {
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Nervous System",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Nervous System"],
     },
     statement: "<p>What happens when an IPSP is generated after EPSP?</p>",
     optionsList: [
@@ -132,9 +132,9 @@ export const questionsData = [
   },
   {
     tags: {
-      course: "VETS2011",
-      subject: "Physiology",
-      system: "Nervous System",
+      course: ["VETS2011"],
+      subject: ["Physiology"],
+      system: ["Nervous System"],
     },
     statement:
       "<p>Which of the following would NOT be possible occurrences when signal build-up occurs?</p>",

--- a/tests/utilFunctionTests/GetUniquePropertyValues.test.ts
+++ b/tests/utilFunctionTests/GetUniquePropertyValues.test.ts
@@ -15,7 +15,7 @@ describe("should return correct tags structure", () => {
   it("should return unique values of the given tags", () => {
     const tags = getUniquePropertyValues(badTags as Tags[]);
     expect(tags).toEqual({
-      course: ["vets2011", "vets2012", "vets2013"],
+      course: ["vets2011", "vets2012", "vets2016", "vets2013"],
       subject: ["physiology", "atonomy"],
       system: ["nervous system"],
       234: ["tagvalue"],

--- a/tests/utilFunctionTests/convertTags.test.ts
+++ b/tests/utilFunctionTests/convertTags.test.ts
@@ -11,10 +11,10 @@ const testTagsData = [
 describe("test convertTags function", () => {
   it("should return the tags with space to replace underscore", () => {
     const expected = {
-      course: "vets2012",
-      subject: "physiology",
-      system: "nervous system",
-      animal: "horse",
+      course: ["vets2012"],
+      subject: ["physiology"],
+      system: ["nervous system"],
+      animal: ["horse"],
     };
     expect(convertTags(testTagsData)).toEqual(expected);
   });


### PR DESCRIPTION
```gitattributes
git fetch
git checkout story/VETHUB-136
```
to test:
run ` yarn test`

to test manually:
1- Currently in the static data, we have two questions with duplicate keys which is course of different value:
one of them:
```typescript
tags: ["course: VETS2013", "course:vets2016", "subject:Physiology"]
``` 
the other is:
```typescript
tags: [
      "course: VETS2012",
      "course:vets2016",
      "subject: Physiology",
      "system: Nervous System",
    ]
``` 
2- run `yarn dev`
3- you should notice that VETS2016 is mentioned twice, VETS2012 is mentioned 10 times ( since we have ten question with this tag), and VETS2013 mentioned twice since there are two questions under this tag
4- Notice that default maximum number of questions that can be selected is 13, since we already have 13 questions in total 
5- press on VETS2016, notice how VETS2012 and VETS2013 only incremented by one each only one question in common with it. (if there wasn't any tags in common it should increment by two, check VETS2011)
 