### PR TITLE
The number count od each topic is now fixed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-yarn build
+yarn build:lib 

--- a/src/components/MCQ/FilterCheckbox.vue
+++ b/src/components/MCQ/FilterCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <ul>
     <li
-      v-for="{ idx, num, topic } in questionsNumByTags"
+      v-for="{ idx, num, topic, questionamount } in questionsNumByTags"
       :key="idx"
       class="filter-options"
       :class="{ 'grey-out': num === '0' }"
@@ -17,7 +17,7 @@
       <label :for="`${category}-${topic}-checkbox`">
         {{ formatTopic(topic) }}
         <span v-if="num !== null && num !== '0'" class="question-number">{{
-          num
+          questionamount
         }}</span></label
       >
     </li>
@@ -27,7 +27,10 @@
 <script setup lang="ts">
 import { SelectedTags } from "@/types/MCQ";
 import { useQuizStore } from "@/store/QuizStore";
-import { filterQuestionsByTags } from "../QuestionStore";
+import {
+  filterQuestionsByTags,
+  filterQuestionsBySingleTopic,
+} from "../QuestionStore";
 import { computed } from "vue";
 const { category, topics } = defineProps<{
   category: string;
@@ -43,7 +46,12 @@ const questionsNumByTags = computed(() =>
   Object.entries(topics)
     .map(([idx, topic]) => {
       const num = getQuestionsnumByTags(topic, category);
-      return { idx, topic, num };
+      const questionamount = filterQuestionsBySingleTopic(
+        questionsQueue.allQs,
+        topic,
+        category,
+      ).length.toString();
+      return { idx, topic, num, questionamount };
     })
     .filter(({ topic }) => topic !== undefined),
 );

--- a/src/components/QuestionStore.ts
+++ b/src/components/QuestionStore.ts
@@ -67,6 +67,17 @@ export function filterQuestionsByTags(
   });
 }
 
+export function filterQuestionsBySingleTopic(
+  questions: MCQuestion[],
+  topic: string,
+  category: string,
+): MCQuestion[] {
+  return questions.filter((question: MCQuestion) => {
+    const questionTags = question.tags[category];
+    return questionTags && questionTags.includes(topic);
+  });
+}
+
 export function findSelectedOptionValue(
   quizStats: QuestionState[],
   questionIndex: number,

--- a/tests/components/FilterCheckbox.test.ts
+++ b/tests/components/FilterCheckbox.test.ts
@@ -6,9 +6,10 @@ import { useQuizStore } from "../../src/store/QuizStore";
 import { questionsData as questions } from "../testSeeds";
 let wrapper: VueWrapper;
 const category: string = "course";
-const topics: string[] = ["VETS2011", "VETS9999"];
+const topics: string[] = ["VETS2011", "VETS9999", "VETS2013"];
 let firstCheckbox: Omit<DOMWrapper<HTMLInputElement>, "exists">;
 let secondCheckbox: Omit<DOMWrapper<HTMLInputElement>, "exists">;
+let thirdCheckbox: Omit<DOMWrapper<HTMLInputElement>, "exists">;
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -25,6 +26,7 @@ beforeEach(() => {
   const checkboxes = wrapper.findAll("input[type='checkbox']");
   firstCheckbox = checkboxes[0] as DOMWrapper<HTMLInputElement>;
   secondCheckbox = checkboxes[1] as DOMWrapper<HTMLInputElement>;
+  thirdCheckbox = checkboxes[2] as DOMWrapper<HTMLInputElement>;
 });
 
 describe("FilterCheckbox.vue", () => {
@@ -58,15 +60,18 @@ it("Should disable and grey out checkboxes with no associated questions", async 
 
 it("Should display question count only for topics with available questions", async () => {
   const questionNumbers = wrapper.findAll(".question-number");
-  expect(questionNumbers.length).toBe(1);
+  expect(questionNumbers.length).toBe(2);
   expect(isNaN(Number(questionNumbers[0].text()))).toBe(false);
+  expect(questionNumbers[0].text()).toBe("2");
 });
 
-it("Should update correctly when props change", async () => {
-  const newTopics = ["VETS2013", "VETS2014"];
-  await wrapper.setProps({ topics: newTopics });
+it("Should update correctly when we select a tag", async () => {
+  const questionsQueue = useQuizStore();
+  questionsQueue.modifySelectedTags(true, {
+    category: "course",
+    topic: "VETS2011",
+  });
 
-  expect(wrapper.findAll("input[type='checkbox']").length).toBe(
-    newTopics.length,
-  );
+  const questionNumbers = wrapper.findAll(".question-number");
+  expect(questionNumbers[1].text()).toBe("1"); // VETS2013
 });

--- a/tests/testSeeds.ts
+++ b/tests/testSeeds.ts
@@ -57,7 +57,7 @@ export const dataTest = [
 export const questionsData = [
   {
     tags: {
-      course: ["VETS2011"],
+      course: ["VETS2013"],
       subject: ["Physiology"],
       system: ["Nervous System"],
     },


### PR DESCRIPTION
```
git fetch
git checkout feature/VETHUB-169
``` 
The number of questions displayed does not update anymore when a user selects a filter tag on the main page of the SMART QUIZ.

to test:
```
yarn test
``` 
or just manually test it and see how the numbers are fixed